### PR TITLE
Fix possible ^W crash.

### DIFF
--- a/vi/v_txt.c
+++ b/vi/v_txt.c
@@ -1106,12 +1106,12 @@ leftmargin:		tp->lb[tp->cno - 1] = ' ';
 		 */
 		if (LF_ISSET(TXT_TTYWERASE))
 			while (tp->cno > max) {
+				if (isblank(tp->lb[tp->cno - 1]))
+					break;
 				--tp->cno;
 				++tp->owrite;
 				if (FL_ISSET(is_flags, IS_RUNNING))
 					tp->lb[tp->cno] = ' ';
-				if (ISBLANK(tp->lb[tp->cno - 1]))
-					break;
 			}
 		else {
 			if (LF_ISSET(TXT_ALTWERASE)) {
@@ -1119,19 +1119,17 @@ leftmargin:		tp->lb[tp->cno - 1] = ' ';
 				++tp->owrite;
 				if (FL_ISSET(is_flags, IS_RUNNING))
 					tp->lb[tp->cno] = ' ';
-				if (ISBLANK(tp->lb[tp->cno - 1]))
-					break;
 			}
 			if (tp->cno > max)
 				tmp = inword(tp->lb[tp->cno - 1]);
 			while (tp->cno > max) {
+				if (tmp != inword(tp->lb[tp->cno - 1])
+				    || isblank(tp->lb[tp->cno - 1]))
+					break;
 				--tp->cno;
 				++tp->owrite;
 				if (FL_ISSET(is_flags, IS_RUNNING))
 					tp->lb[tp->cno] = ' ';
-				if (tmp != inword(tp->lb[tp->cno - 1])
-				    || ISBLANK(tp->lb[tp->cno - 1]))
-					break;
 			}
 		}
 


### PR DESCRIPTION
I agree, this is not the same crash as in Issue #1, but I did hit this one today (checked the backtrace). :)

Original commit message by millert@openbsd:
When ^W (WERASE) is hit in insert mode it's possible that the line
buffer is accessed out of bounds. If 'max' == 0 and 'tp->cno' == 1
the 'tp->cno' value is first reduced by one and then 'tp->lb' is
accessed at 'tp->cno' - 1.  Also remove dead (and incorrect) code
in the TXT_ALTWERASE case.  From Arto Jonsson; OK martynas@

backtrace, for reference:
#0  0x00001fe3be94466c in v_txt (sp=0x1fe5ca899630, vp=0x7f7fffff95a0, tm=Variable "tm" is not available.

)
    at /usr/ports/pobj/nvi-2.1.1-iconv/nvi-2.1.1/vi/v_txt.c:1132
#1  0x00001fe3be93c867 in v_change (sp=0x1fe5ca899630, vp=0x7f7fffff95a0)

```
at /usr/ports/pobj/nvi-2.1.1-iconv/nvi-2.1.1/vi/v_itxt.c:314
```
#2  0x00001fe3be948531 in vi (spp=0x7f7fffff97b8)

```
at /usr/ports/pobj/nvi-2.1.1-iconv/nvi-2.1.1/vi/vi.c:229
```
#3  0x00001fe3be91773a in editor (gp=0x1fe5ce7cf000, argc=2,

```
argv=0x7f7fffff99a8)
at /usr/ports/pobj/nvi-2.1.1-iconv/nvi-2.1.1/common/main.c:421
```
#4  0x00001fe3be90d4d1 in main (argc=2, argv=0x7f7fffff99a0)

```
at /usr/ports/pobj/nvi-2.1.1-iconv/nvi-2.1.1/cl/cl_main.c:120
```
