### PR TITLE
Clean up uses of the old __P() macro.

### DIFF
--- a/cl/cl_funcs.c
+++ b/cl/cl_funcs.c
@@ -33,7 +33,7 @@ static const char sccsid[] = "$Id: cl_funcs.c,v 10.74 2012/10/11 10:30:16 zy Exp
 #include "../vi/vi.h"
 #include "cl.h"
 
-static void cl_rdiv __P((SCR *));
+static void cl_rdiv(SCR *);
 
 static int 
 addstr4(SCR *sp, void *str, size_t len, int wide)
@@ -76,7 +76,7 @@ addstr4(SCR *sp, void *str, size_t len, int wide)
  * cl_waddstr --
  *	Add len bytes from the string at the cursor, advancing the cursor.
  *
- * PUBLIC: int cl_waddstr __P((SCR *, const CHAR_T *, size_t));
+ * PUBLIC: int cl_waddstr(SCR *, const CHAR_T *, size_t);
  */
 int
 cl_waddstr(SCR *sp, const CHAR_T *str, size_t len)
@@ -88,7 +88,7 @@ cl_waddstr(SCR *sp, const CHAR_T *str, size_t len)
  * cl_addstr --
  *	Add len bytes from the string at the cursor, advancing the cursor.
  *
- * PUBLIC: int cl_addstr __P((SCR *, const char *, size_t));
+ * PUBLIC: int cl_addstr(SCR *, const char *, size_t);
  */
 int
 cl_addstr(SCR *sp, const char *str, size_t len)
@@ -100,7 +100,7 @@ cl_addstr(SCR *sp, const char *str, size_t len)
  * cl_attr --
  *	Toggle a screen attribute on/off.
  *
- * PUBLIC: int cl_attr __P((SCR *, scr_attr_t, int));
+ * PUBLIC: int cl_attr(SCR *, scr_attr_t, int);
  */
 int
 cl_attr(SCR *sp, scr_attr_t attribute, int on)
@@ -187,7 +187,7 @@ cl_attr(SCR *sp, scr_attr_t attribute, int on)
  * cl_baud --
  *	Return the baud rate.
  *
- * PUBLIC: int cl_baud __P((SCR *, u_long *));
+ * PUBLIC: int cl_baud(SCR *, u_long *);
  */
 int
 cl_baud(SCR *sp, u_long *ratep)
@@ -228,7 +228,7 @@ cl_baud(SCR *sp, u_long *ratep)
  * cl_bell --
  *	Ring the bell/flash the screen.
  *
- * PUBLIC: int cl_bell __P((SCR *));
+ * PUBLIC: int cl_bell(SCR *);
  */
 int
 cl_bell(SCR *sp)
@@ -252,7 +252,7 @@ cl_bell(SCR *sp)
  * cl_clrtoeol --
  *	Clear from the current cursor to the end of the line.
  *
- * PUBLIC: int cl_clrtoeol __P((SCR *));
+ * PUBLIC: int cl_clrtoeol(SCR *);
  */
 int
 cl_clrtoeol(SCR *sp)
@@ -281,7 +281,7 @@ cl_clrtoeol(SCR *sp)
  * cl_cursor --
  *	Return the current cursor position.
  *
- * PUBLIC: int cl_cursor __P((SCR *, size_t *, size_t *));
+ * PUBLIC: int cl_cursor(SCR *, size_t *, size_t *);
  */
 int
 cl_cursor(SCR *sp, size_t *yp, size_t *xp)
@@ -307,7 +307,7 @@ cl_cursor(SCR *sp, size_t *yp, size_t *xp)
  * cl_deleteln --
  *	Delete the current line, scrolling all lines below it.
  *
- * PUBLIC: int cl_deleteln __P((SCR *));
+ * PUBLIC: int cl_deleteln(SCR *);
  */
 int
 cl_deleteln(SCR *sp)
@@ -344,7 +344,7 @@ cl_deleteln(SCR *sp)
  * cl_discard --
  *	Discard a screen.
  *
- * PUBLIC: int cl_discard __P((SCR *, SCR **));
+ * PUBLIC: int cl_discard(SCR *, SCR **);
  */
 int
 cl_discard(SCR *discardp, SCR **acquirep)
@@ -385,7 +385,7 @@ cl_discard(SCR *discardp, SCR **acquirep)
  *	Adjust the screen for ex.  This routine is purely for standalone
  *	ex programs.  All special purpose, all special case.
  *
- * PUBLIC: int cl_ex_adjust __P((SCR *, exadj_t));
+ * PUBLIC: int cl_ex_adjust(SCR *, exadj_t);
  */
 int
 cl_ex_adjust(SCR *sp, exadj_t action)
@@ -440,7 +440,7 @@ cl_ex_adjust(SCR *sp, exadj_t action)
  * cl_insertln --
  *	Push down the current line, discarding the bottom line.
  *
- * PUBLIC: int cl_insertln __P((SCR *));
+ * PUBLIC: int cl_insertln(SCR *);
  */
 int
 cl_insertln(SCR *sp)
@@ -458,7 +458,7 @@ cl_insertln(SCR *sp)
  * cl_keyval --
  *	Return the value for a special key.
  *
- * PUBLIC: int cl_keyval __P((SCR *, scr_keyval_t, CHAR_T *, int *));
+ * PUBLIC: int cl_keyval(SCR *, scr_keyval_t, CHAR_T *, int *);
  */
 int
 cl_keyval(SCR *sp, scr_keyval_t val, CHAR_T *chp, int *dnep)
@@ -496,7 +496,7 @@ cl_keyval(SCR *sp, scr_keyval_t val, CHAR_T *chp, int *dnep)
  * cl_move --
  *	Move the cursor.
  *
- * PUBLIC: int cl_move __P((SCR *, size_t, size_t));
+ * PUBLIC: int cl_move(SCR *, size_t, size_t);
  */
 int
 cl_move(SCR *sp, size_t lno, size_t cno)
@@ -516,7 +516,7 @@ cl_move(SCR *sp, size_t lno, size_t cno)
  * cl_refresh --
  *	Refresh the screen.
  *
- * PUBLIC: int cl_refresh __P((SCR *, int));
+ * PUBLIC: int cl_refresh(SCR *, int);
  */
 int
 cl_refresh(SCR *sp, int repaint)
@@ -599,7 +599,7 @@ cl_rdiv(SCR *sp)
  * cl_rename --
  *	Rename the file.
  *
- * PUBLIC: int cl_rename __P((SCR *, char *, int));
+ * PUBLIC: int cl_rename(SCR *, char *, int);
  */
 int
 cl_rename(SCR *sp, char *name, int on)
@@ -654,7 +654,7 @@ rename:		cl_setname(gp, name);
  * cl_setname --
  *	Set a X11 icon/window name.
  *
- * PUBLIC: void cl_setname __P((GS *, char *));
+ * PUBLIC: void cl_setname(GS *, char *);
  */
 void
 cl_setname(GS *gp, char *name)
@@ -671,7 +671,7 @@ cl_setname(GS *gp, char *name)
  * cl_split --
  *	Split a screen.
  *
- * PUBLIC: int cl_split __P((SCR *, SCR *));
+ * PUBLIC: int cl_split(SCR *, SCR *);
  */
 int
 cl_split(SCR *origp, SCR *newp)
@@ -697,7 +697,7 @@ cl_split(SCR *origp, SCR *newp)
  * cl_suspend --
  *	Suspend a screen.
  *
- * PUBLIC: int cl_suspend __P((SCR *, int *));
+ * PUBLIC: int cl_suspend(SCR *, int *);
  */
 int
 cl_suspend(SCR *sp, int *allowedp)
@@ -825,7 +825,7 @@ cl_suspend(SCR *sp, int *allowedp)
  * cl_usage --
  *	Print out the curses usage messages.
  * 
- * PUBLIC: void cl_usage __P((void));
+ * PUBLIC: void cl_usage(void);
  */
 void
 cl_usage(void)

--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -36,13 +36,13 @@ static const char sccsid[] = "$Id: cl_main.c,v 10.55 2011/08/15 19:52:28 zy Exp 
 GS *__global_list;				/* GLOBAL: List of screens. */
 sigset_t __sigblockset;				/* GLOBAL: Blocked signals. */
 
-static void	   cl_func_std __P((GS *));
-static CL_PRIVATE *cl_init __P((GS *));
-static GS	  *gs_init __P((char *));
-static void	   perr __P((char *, char *));
-static int	   setsig __P((int, struct sigaction *, void (*)(int)));
-static void	   sig_end __P((GS *));
-static void	   term_init __P((char *, char *));
+static void	   cl_func_std(GS *);
+static CL_PRIVATE *cl_init(GS *);
+static GS	  *gs_init(char *);
+static void	   perr(char *, char *);
+static int	   setsig(int, struct sigaction *, void (*)(int));
+static void	   sig_end(GS *);
+static void	   term_init(char *, char *);
 
 /*
  * main --
@@ -292,7 +292,7 @@ h_winch(int signo)
  * sig_init --
  *	Initialize signals.
  *
- * PUBLIC: int sig_init __P((GS *, SCR *));
+ * PUBLIC: int sig_init(GS *, SCR *);
  */
 int
 sig_init(GS *gp, SCR *sp)

--- a/cl/cl_read.c
+++ b/cl/cl_read.c
@@ -35,15 +35,15 @@ static const char sccsid[] = "$Id: cl_read.c,v 10.30 2012/07/12 18:28:58 zy Exp 
 #undef columns
 #undef lines  
 
-static input_t	cl_read __P((SCR *,
-    u_int32_t, char *, size_t, int *, struct timeval *));
-static int	cl_resize __P((SCR *, size_t, size_t));
+static input_t	cl_read(SCR *,
+    u_int32_t, char *, size_t, int *, struct timeval *);
+static int	cl_resize(SCR *, size_t, size_t);
 
 /*
  * cl_event --
  *	Return a single event.
  *
- * PUBLIC: int cl_event __P((SCR *, EVENT *, u_int32_t, int));
+ * PUBLIC: int cl_event(SCR *, EVENT *, u_int32_t, int);
  */
 int
 cl_event(SCR *sp, EVENT *evp, u_int32_t flags, int ms)

--- a/cl/cl_screen.c
+++ b/cl/cl_screen.c
@@ -32,18 +32,18 @@ static const char sccsid[] = "$Id: cl_screen.c,v 10.56 2002/05/03 19:59:44 skimo
 #include "../common/common.h"
 #include "cl.h"
 
-static int	cl_ex_end __P((GS *));
-static int	cl_ex_init __P((SCR *));
-static void	cl_freecap __P((CL_PRIVATE *));
-static int	cl_vi_end __P((GS *));
-static int	cl_vi_init __P((SCR *));
-static int	cl_putenv __P((char *, char *, u_long));
+static int	cl_ex_end(GS *);
+static int	cl_ex_init(SCR *);
+static void	cl_freecap(CL_PRIVATE *);
+static int	cl_vi_end(GS *);
+static int	cl_vi_init(SCR *);
+static int	cl_putenv(char *, char *, u_long);
 
 /*
  * cl_screen --
  *	Switch screen types.
  *
- * PUBLIC: int cl_screen __P((SCR *, u_int32_t));
+ * PUBLIC: int cl_screen(SCR *, u_int32_t);
  */
 int
 cl_screen(SCR *sp, u_int32_t flags)
@@ -131,7 +131,7 @@ cl_screen(SCR *sp, u_int32_t flags)
  * cl_quit --
  *	Shutdown the screens.
  *
- * PUBLIC: int cl_quit __P((GS *));
+ * PUBLIC: int cl_quit(GS *);
  */
 int
 cl_quit(GS *gp)
@@ -520,7 +520,7 @@ cl_ex_end(GS *gp)
  * cl_getcap --
  *	Retrieve termcap/terminfo strings.
  *
- * PUBLIC: int cl_getcap __P((SCR *, char *, char **));
+ * PUBLIC: int cl_getcap(SCR *, char *, char **);
  */
 int
 cl_getcap(SCR *sp, char *name, char **elementp)

--- a/cl/cl_term.c
+++ b/cl/cl_term.c
@@ -34,7 +34,7 @@ static const char sccsid[] = "$Id: cl_term.c,v 10.34 2013/12/07 16:21:14 wjenkne
 #include "../common/common.h"
 #include "cl.h"
 
-static int cl_pfmap __P((SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t));
+static int cl_pfmap(SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t);
 
 /*
  * XXX
@@ -81,7 +81,7 @@ static TKLIST const m2_tklist[] = {	/* Input mappings (set or delete). */
  * cl_term_init --
  *	Initialize the special keys defined by the termcap/terminfo entry.
  *
- * PUBLIC: int cl_term_init __P((SCR *));
+ * PUBLIC: int cl_term_init(SCR *);
  */
 int
 cl_term_init(SCR *sp)
@@ -182,7 +182,7 @@ cl_term_init(SCR *sp)
  * cl_term_end --
  *	End the special keys defined by the termcap/terminfo entry.
  *
- * PUBLIC: int cl_term_end __P((GS *));
+ * PUBLIC: int cl_term_end(GS *);
  */
 int
 cl_term_end(GS *gp)
@@ -206,7 +206,7 @@ cl_term_end(GS *gp)
  * cl_fmap --
  *	Map a function key.
  *
- * PUBLIC: int cl_fmap __P((SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t));
+ * PUBLIC: int cl_fmap(SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t);
  */
 int
 cl_fmap(SCR *sp, seq_t stype, CHAR_T *from, size_t flen, CHAR_T *to, size_t tlen)
@@ -258,7 +258,7 @@ cl_pfmap(SCR *sp, seq_t stype, CHAR_T *from, size_t flen, CHAR_T *to, size_t tle
  * cl_optchange --
  *	Curses screen specific "option changed" routine.
  *
- * PUBLIC: int cl_optchange __P((SCR *, int, char *, u_long *));
+ * PUBLIC: int cl_optchange(SCR *, int, char *, u_long *);
  */
 int
 cl_optchange(SCR *sp, int opt, char *str, u_long *valp)
@@ -305,7 +305,7 @@ cl_optchange(SCR *sp, int opt, char *str, u_long *valp)
  * cl_omesg --
  *	Turn the tty write permission on or off.
  *
- * PUBLIC: int cl_omesg __P((SCR *, CL_PRIVATE *, int));
+ * PUBLIC: int cl_omesg(SCR *, CL_PRIVATE *, int);
  */
 int
 cl_omesg(SCR *sp, CL_PRIVATE *clp, int on)
@@ -351,7 +351,7 @@ cl_omesg(SCR *sp, CL_PRIVATE *clp, int on)
  * cl_ssize --
  *	Return the terminal size.
  *
- * PUBLIC: int cl_ssize __P((SCR *, int, size_t *, size_t *, int *));
+ * PUBLIC: int cl_ssize(SCR *, int, size_t *, size_t *, int *);
  */
 int
 cl_ssize(SCR *sp, int sigwinch, size_t *rowp, size_t *colp, int *changedp)
@@ -467,7 +467,7 @@ noterm:	if (row == 0)
  * cl_putchar --
  *	Function version of putchar, for tputs.
  *
- * PUBLIC: int cl_putchar __P((int));
+ * PUBLIC: int cl_putchar(int);
  */
 int
 cl_putchar(int ch)

--- a/common/conv.c
+++ b/common/conv.c
@@ -36,7 +36,7 @@ static const char sccsid[] = "$Id: conv.c,v 2.40 2014/02/27 16:25:29 zy Exp $";
  * codeset --
  *	Get the locale encoding.
  *
- * PUBLIC: char * codeset __P((void));
+ * PUBLIC: char * codeset(void);
  */
 char *
 codeset(void)
@@ -308,7 +308,7 @@ cs_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw,
  * conv_init --
  *	Initialize the iconv environment.
  *
- * PUBLIC: void conv_init __P((SCR *, SCR *));
+ * PUBLIC: void conv_init(SCR *, SCR *);
  */
 void
 conv_init(SCR *orig, SCR *sp)
@@ -367,7 +367,7 @@ conv_init(SCR *orig, SCR *sp)
  * conv_enc --
  *	Convert file/input encoding.
  *
- * PUBLIC: int conv_enc __P((SCR *, int, char *));
+ * PUBLIC: int conv_enc(SCR *, int, char *);
  */
 int
 conv_enc(SCR *sp, int option, char *enc)
@@ -446,7 +446,7 @@ err:
  * conv_end --
  *	Close the iconv descriptors, release the buffer.
  *
- * PUBLIC: void conv_end __P((SCR *));
+ * PUBLIC: void conv_end(SCR *);
  */
 void
 conv_end(SCR *sp)

--- a/common/cut.c
+++ b/common/cut.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: cut.c,v 10.12 2012/02/11 15:52:33 zy Exp $";
 
 #include "common.h"
 
-static void	cb_rotate __P((SCR *));
+static void	cb_rotate(SCR *);
 
 /*
  * cut --
@@ -61,7 +61,7 @@ static void	cb_rotate __P((SCR *));
  * replacing the contents.  Hopefully it's not worth getting right, and here
  * we just treat the numeric buffers like any other named buffer.
  *
- * PUBLIC: int cut __P((SCR *, CHAR_T *, MARK *, MARK *, int));
+ * PUBLIC: int cut(SCR *, CHAR_T *, MARK *, MARK *, int);
  */
 int
 cut(
@@ -222,7 +222,7 @@ cb_rotate(SCR *sp)
  * cut_line --
  *	Cut a portion of a single line.
  *
- * PUBLIC: int cut_line __P((SCR *, recno_t, size_t, size_t, CB *));
+ * PUBLIC: int cut_line(SCR *, recno_t, size_t, size_t, CB *);
  */
 int
 cut_line(
@@ -266,7 +266,7 @@ cut_line(
  * cut_close --
  *	Discard all cut buffers.
  *
- * PUBLIC: void cut_close __P((GS *));
+ * PUBLIC: void cut_close(GS *);
  */
 void
 cut_close(GS *gp)
@@ -291,7 +291,7 @@ cut_close(GS *gp)
  * text_init --
  *	Allocate a new TEXT structure.
  *
- * PUBLIC: TEXT *text_init __P((SCR *, const CHAR_T *, size_t, size_t));
+ * PUBLIC: TEXT *text_init(SCR *, const CHAR_T *, size_t, size_t);
  */
 TEXT *
 text_init(
@@ -323,7 +323,7 @@ text_init(
  * text_lfree --
  *	Free a chain of text structures.
  *
- * PUBLIC: void text_lfree __P((TEXTH *));
+ * PUBLIC: void text_lfree(TEXTH *);
  */
 void
 text_lfree(TEXTH *headp)
@@ -340,7 +340,7 @@ text_lfree(TEXTH *headp)
  * text_free --
  *	Free a text structure.
  *
- * PUBLIC: void text_free __P((TEXT *));
+ * PUBLIC: void text_free(TEXT *);
  */
 void
 text_free(TEXT *tp)

--- a/common/delete.c
+++ b/common/delete.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: delete.c,v 10.18 2012/02/11 15:52:33 zy Exp $
  * del --
  *	Delete a range of text.
  *
- * PUBLIC: int del __P((SCR *, MARK *, MARK *, int));
+ * PUBLIC: int del(SCR *, MARK *, MARK *, int);
  */
 int
 del(

--- a/common/encoding.c
+++ b/common/encoding.c
@@ -11,10 +11,10 @@ static const char sccsid[] = "$Id: encoding.c,v 1.4 2011/12/13 19:40:52 zy Exp $
 
 #include <sys/types.h>
 
-int looks_utf8 __P((const char *, size_t));
-int looks_utf16 __P((const char *, size_t));
-int decode_utf8 __P((const char *));
-int decode_utf16 __P((const char *, int));
+int looks_utf8(const char *, size_t);
+int looks_utf16(const char *, size_t);
+int decode_utf8(const char *);
+int decode_utf16(const char *, int);
 
 #define F 0   /* character never appears in text */
 #define T 1   /* character appears in plain ASCII text */
@@ -54,7 +54,7 @@ static char text_chars[256] = {
  *
  *  Based on RFC 3629. UTF-8 with BOM is not accepted.
  *
- * PUBLIC: int looks_utf8 __P((const char *, size_t));
+ * PUBLIC: int looks_utf8(const char *, size_t);
  */
 int
 looks_utf8(const char *ibuf, size_t nbytes)
@@ -115,7 +115,7 @@ done:
  *      1: Little-endian UTF-16
  *      2: Big-endian UTF-16
  *
- * PUBLIC: int looks_utf16 __P((const char *, size_t));
+ * PUBLIC: int looks_utf16(const char *, size_t);
  */
 int
 looks_utf16(const char *ibuf, size_t nbytes)
@@ -175,7 +175,7 @@ looks_utf16(const char *ibuf, size_t nbytes)
  *
  *  Based on RFC 3629, but without error detection.
  *
- * PUBLIC: int decode_utf8 __P((const char *));
+ * PUBLIC: int decode_utf8(const char *);
  */
 int
 decode_utf8(const char *ibuf)
@@ -207,7 +207,7 @@ decode_utf8(const char *ibuf)
  *
  *  No error detection on supplementary bytes.
  *
- * PUBLIC: int decode_utf16 __P((const char *, int));
+ * PUBLIC: int decode_utf16(const char *, int);
  */
 int
 decode_utf16(const char* ibuf, int bigend)

--- a/common/exf.c
+++ b/common/exf.c
@@ -37,11 +37,11 @@ static const char sccsid[] = "$Id: exf.c,v 10.62 2014/03/05 15:40:43 zy Exp $";
 
 #include "common.h"
 
-static int	file_backup __P((SCR *, char *, char *));
-static void	file_cinit __P((SCR *));
-static void	file_encinit __P((SCR *));
-static void	file_comment __P((SCR *));
-static int	file_spath __P((SCR *, FREF *, struct stat *, int *));
+static int	file_backup(SCR *, char *, char *);
+static void	file_cinit(SCR *);
+static void	file_encinit(SCR *);
+static void	file_comment(SCR *);
+static int	file_spath(SCR *, FREF *, struct stat *, int *);
 
 /*
  * file_add --
@@ -56,7 +56,7 @@ static int	file_spath __P((SCR *, FREF *, struct stat *, int *));
  * vi now remembers the last location in any file that it has ever edited,
  * not just the previously edited file.
  *
- * PUBLIC: FREF *file_add __P((SCR *, char *));
+ * PUBLIC: FREF *file_add(SCR *, char *);
  */
 FREF *
 file_add(
@@ -118,7 +118,7 @@ file_add(
  *	let go of any previous file.  Don't release the previous file until
  *	absolutely sure we have the new one.
  *
- * PUBLIC: int file_init __P((SCR *, FREF *, char *, int));
+ * PUBLIC: int file_init(SCR *, FREF *, char *, int);
  */
 int
 file_init(
@@ -625,7 +625,7 @@ file_cinit(SCR *sp)
  * file_end --
  *	Stop editing a file.
  *
- * PUBLIC: int file_end __P((SCR *, EXF *, int));
+ * PUBLIC: int file_end(SCR *, EXF *, int);
  */
 int
 file_end(
@@ -737,7 +737,7 @@ file_end(
  *	semantics for whether or not writes would happen.  That's
  *	why all the flags.
  *
- * PUBLIC: int file_write __P((SCR *, MARK *, MARK *, char *, int));
+ * PUBLIC: int file_write(SCR *, MARK *, MARK *, char *, int);
  */
 int
 file_write(
@@ -1302,7 +1302,7 @@ file_comment(SCR *sp)
  * 	First modification check routine.  The :next, :prev, :rewind, :tag,
  *	:tagpush, :tagpop, ^^ modifications check.
  *
- * PUBLIC: int file_m1 __P((SCR *, int, int));
+ * PUBLIC: int file_m1(SCR *, int, int);
  */
 int
 file_m1(
@@ -1343,7 +1343,7 @@ file_m1(
  * 	Second modification check routine.  The :edit, :quit, :recover
  *	modifications check.
  *
- * PUBLIC: int file_m2 __P((SCR *, int));
+ * PUBLIC: int file_m2(SCR *, int);
  */
 int
 file_m2(
@@ -1375,7 +1375,7 @@ file_m2(
  * file_m3 --
  * 	Third modification check routine.
  *
- * PUBLIC: int file_m3 __P((SCR *, int));
+ * PUBLIC: int file_m3(SCR *, int);
  */
 int
 file_m3(
@@ -1411,7 +1411,7 @@ file_m3(
  *	is not set, write the file.  A routine so there's a place to put the
  *	comment.
  *
- * PUBLIC: int file_aw __P((SCR *, int));
+ * PUBLIC: int file_aw(SCR *, int);
  */
 int
 file_aw(
@@ -1472,7 +1472,7 @@ file_aw(
  * If the user edits a temporary file, there may be times when there is no
  * alternative file name.  A name argument of NULL turns it off.
  *
- * PUBLIC: void set_alt_name __P((SCR *, char *));
+ * PUBLIC: void set_alt_name(SCR *, char *);
  */
 void
 set_alt_name(
@@ -1491,7 +1491,7 @@ set_alt_name(
  * file_lock --
  *	Get an exclusive lock on a file.
  *
- * PUBLIC: lockr_t file_lock __P((SCR *, char *, int, int));
+ * PUBLIC: lockr_t file_lock(SCR *, char *, int, int);
  */
 lockr_t
 file_lock(

--- a/common/gs.h
+++ b/common/gs.h
@@ -144,57 +144,57 @@ struct _gs {
 
 	/* Screen interface functions. */
 					/* Add a string to the screen. */
-	int	(*scr_addstr) __P((SCR *, const char *, size_t));
+	int	(*scr_addstr)(SCR *, const char *, size_t);
 					/* Add a string to the screen. */
-	int	(*scr_waddstr) __P((SCR *, const CHAR_T *, size_t));
+	int	(*scr_waddstr)(SCR *, const CHAR_T *, size_t);
 					/* Toggle a screen attribute. */
-	int	(*scr_attr) __P((SCR *, scr_attr_t, int));
+	int	(*scr_attr)(SCR *, scr_attr_t, int);
 					/* Terminal baud rate. */
-	int	(*scr_baud) __P((SCR *, u_long *));
+	int	(*scr_baud)(SCR *, u_long *);
 					/* Beep/bell/flash the terminal. */
-	int	(*scr_bell) __P((SCR *));
+	int	(*scr_bell)(SCR *);
 					/* Display a busy message. */
-	void	(*scr_busy) __P((SCR *, const char *, busy_t));
+	void	(*scr_busy)(SCR *, const char *, busy_t);
 					/* Prepare child. */
-	int	(*scr_child) __P((SCR *));
+	int	(*scr_child)(SCR *);
 					/* Clear to the end of the line. */
-	int	(*scr_clrtoeol) __P((SCR *));
+	int	(*scr_clrtoeol)(SCR *);
 					/* Return the cursor location. */
-	int	(*scr_cursor) __P((SCR *, size_t *, size_t *));
+	int	(*scr_cursor)(SCR *, size_t *, size_t *);
 					/* Delete a line. */
-	int	(*scr_deleteln) __P((SCR *));
+	int	(*scr_deleteln)(SCR *);
 					/* Discard a screen. */
-	int	(*scr_discard) __P((SCR *, SCR **));
+	int	(*scr_discard)(SCR *, SCR **);
 					/* Get a keyboard event. */
-	int	(*scr_event) __P((SCR *, EVENT *, u_int32_t, int));
+	int	(*scr_event)(SCR *, EVENT *, u_int32_t, int);
 					/* Ex: screen adjustment routine. */
-	int	(*scr_ex_adjust) __P((SCR *, exadj_t));
+	int	(*scr_ex_adjust)(SCR *, exadj_t);
 	int	(*scr_fmap)		/* Set a function key. */
-	    __P((SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t));
+	   (SCR *, seq_t, CHAR_T *, size_t, CHAR_T *, size_t);
 					/* Get terminal key value. */
-	int	(*scr_keyval) __P((SCR *, scr_keyval_t, CHAR_T *, int *));
+	int	(*scr_keyval)(SCR *, scr_keyval_t, CHAR_T *, int *);
 					/* Insert a line. */
-	int	(*scr_insertln) __P((SCR *));
+	int	(*scr_insertln)(SCR *);
 					/* Handle an option change. */
-	int	(*scr_optchange) __P((SCR *, int, char *, u_long *));
+	int	(*scr_optchange)(SCR *, int, char *, u_long *);
 					/* Move the cursor. */
-	int	(*scr_move) __P((SCR *, size_t, size_t));
+	int	(*scr_move)(SCR *, size_t, size_t);
 					/* Message or ex output. */
-	void	(*scr_msg) __P((SCR *, mtype_t, char *, size_t));
+	void	(*scr_msg)(SCR *, mtype_t, char *, size_t);
 					/* Refresh the screen. */
-	int	(*scr_refresh) __P((SCR *, int));
+	int	(*scr_refresh)(SCR *, int);
 					/* Rename the file. */
-	int	(*scr_rename) __P((SCR *, char *, int));
+	int	(*scr_rename)(SCR *, char *, int);
 					/* Reply to an event. */
-	int	(*scr_reply) __P((SCR *, int, char *));
+	int	(*scr_reply)(SCR *, int, char *);
 					/* Set the screen type. */
-	int	(*scr_screen) __P((SCR *, u_int32_t));
+	int	(*scr_screen)(SCR *, u_int32_t);
 					/* Split the screen. */
-	int	(*scr_split) __P((SCR *, SCR *));
+	int	(*scr_split)(SCR *, SCR *);
 					/* Suspend the editor. */
-	int	(*scr_suspend) __P((SCR *, int *));
+	int	(*scr_suspend)(SCR *, int *);
 					/* Print usage message. */
-	void	(*scr_usage) __P((void));
+	void	(*scr_usage)(void);
 };
 
 /*

--- a/common/key.c
+++ b/common/key.c
@@ -30,11 +30,11 @@ static const char sccsid[] = "$Id: key.c,v 10.54 2013/11/13 12:15:27 zy Exp $";
 #include "common.h"
 #include "../vi/vi.h"
 
-static int	v_event_append __P((SCR *, EVENT *));
-static int	v_event_grow __P((SCR *, int));
-static int	v_key_cmp __P((const void *, const void *));
-static void	v_keyval __P((SCR *, int, scr_keyval_t));
-static void	v_sync __P((SCR *, int));
+static int	v_event_append(SCR *, EVENT *);
+static int	v_event_grow(SCR *, int);
+static int	v_key_cmp(const void *, const void *);
+static void	v_keyval(SCR *, int, scr_keyval_t);
+static void	v_sync(SCR *, int);
 
 /*
  * !!!
@@ -97,7 +97,7 @@ static int nkeylist =
  * v_key_init --
  *	Initialize the special key lookup table.
  *
- * PUBLIC: int v_key_init __P((SCR *));
+ * PUBLIC: int v_key_init(SCR *);
  */
 int
 v_key_init(SCR *sp)
@@ -179,7 +179,7 @@ v_keyval(
  * v_key_ilookup --
  *	Build the fast-lookup key display array.
  *
- * PUBLIC: void v_key_ilookup __P((SCR *));
+ * PUBLIC: void v_key_ilookup(SCR *);
  */
 void
 v_key_ilookup(SCR *sp)
@@ -203,7 +203,7 @@ v_key_ilookup(SCR *sp)
  *	Return the length of the string that will display the key.
  *	This routine is the backup for the KEY_LEN() macro.
  *
- * PUBLIC: size_t v_key_len __P((SCR *, ARG_CHAR_T));
+ * PUBLIC: size_t v_key_len(SCR *, ARG_CHAR_T);
  */
 size_t
 v_key_len(
@@ -219,7 +219,7 @@ v_key_len(
  *	Return the string that will display the key.  This routine
  *	is the backup for the KEY_NAME() macro.
  *
- * PUBLIC: char *v_key_name __P((SCR *, ARG_CHAR_T));
+ * PUBLIC: char *v_key_name(SCR *, ARG_CHAR_T);
  */
 char *
 v_key_name(
@@ -327,7 +327,7 @@ done:	sp->cname[sp->clen = len] = '\0';
  *	Fill in the value for a key.  This routine is the backup
  *	for the KEY_VAL() macro.
  *
- * PUBLIC: e_key_t v_key_val __P((SCR *, ARG_CHAR_T));
+ * PUBLIC: e_key_t v_key_val(SCR *, ARG_CHAR_T);
  */
 e_key_t
 v_key_val(
@@ -351,7 +351,7 @@ v_key_val(
  * an associated flag value, which indicates if it has already been quoted,
  * and if it is the result of a mapping or an abbreviation.
  *
- * PUBLIC: int v_event_push __P((SCR *, EVENT *, CHAR_T *, size_t, u_int));
+ * PUBLIC: int v_event_push(SCR *, EVENT *, CHAR_T *, size_t, u_int);
  */
 int
 v_event_push(
@@ -532,7 +532,7 @@ v_event_append(
  * point.  Given that this might make the log grow unacceptably (consider that
  * cursor keys are done with maps), for now we leave any changes made in place.
  *
- * PUBLIC: int v_event_get __P((SCR *, EVENT *, int, u_int32_t));
+ * PUBLIC: int v_event_get(SCR *, EVENT *, int, u_int32_t);
  */
 int
 v_event_get(
@@ -771,7 +771,7 @@ v_sync(
  * v_event_err --
  *	Unexpected event.
  *
- * PUBLIC: void v_event_err __P((SCR *, EVENT *));
+ * PUBLIC: void v_event_err(SCR *, EVENT *);
  */
 void
 v_event_err(
@@ -821,7 +821,7 @@ v_event_err(
  * v_event_flush --
  *	Flush any flagged keys, returning if any keys were flushed.
  *
- * PUBLIC: int v_event_flush __P((SCR *, u_int));
+ * PUBLIC: int v_event_flush(SCR *, u_int);
  */
 int
 v_event_flush(

--- a/common/line.c
+++ b/common/line.c
@@ -26,13 +26,13 @@ static const char sccsid[] = "$Id: line.c,v 10.26 2011/08/12 12:36:41 zy Exp $";
 #include "common.h"
 #include "../vi/vi.h"
 
-static int scr_update __P((SCR *, recno_t, lnop_t, int));
+static int scr_update(SCR *, recno_t, lnop_t, int);
 
 /*
  * db_eget --
  *	Front-end to db_get, special case handling for empty files.
  *
- * PUBLIC: int db_eget __P((SCR *, recno_t, CHAR_T **, size_t *, int *));
+ * PUBLIC: int db_eget(SCR *, recno_t, CHAR_T **, size_t *, int *);
  */
 int
 db_eget(
@@ -76,7 +76,7 @@ db_eget(
  *	Look in the text buffers for a line, followed by the cache, followed
  *	by the database.
  *
- * PUBLIC: int db_get __P((SCR *, recno_t, u_int32_t, CHAR_T **, size_t *));
+ * PUBLIC: int db_get(SCR *, recno_t, u_int32_t, CHAR_T **, size_t *);
  */
 int
 db_get(
@@ -207,7 +207,7 @@ err3:		if (lenp != NULL)
  * db_delete --
  *	Delete a line from the file.
  *
- * PUBLIC: int db_delete __P((SCR *, recno_t));
+ * PUBLIC: int db_delete(SCR *, recno_t);
  */
 int
 db_delete(
@@ -265,7 +265,7 @@ db_delete(
  * db_append --
  *	Append a line into the file.
  *
- * PUBLIC: int db_append __P((SCR *, int, recno_t, CHAR_T *, size_t));
+ * PUBLIC: int db_append(SCR *, int, recno_t, CHAR_T *, size_t);
  */
 int
 db_append(
@@ -343,7 +343,7 @@ db_append(
  * db_insert --
  *	Insert a line into the file.
  *
- * PUBLIC: int db_insert __P((SCR *, recno_t, CHAR_T *, size_t));
+ * PUBLIC: int db_insert(SCR *, recno_t, CHAR_T *, size_t);
  */
 int
 db_insert(
@@ -412,7 +412,7 @@ db_insert(
  * db_set --
  *	Store a line in the file.
  *
- * PUBLIC: int db_set __P((SCR *, recno_t, CHAR_T *, size_t));
+ * PUBLIC: int db_set(SCR *, recno_t, CHAR_T *, size_t);
  */
 int
 db_set(
@@ -474,7 +474,7 @@ db_set(
  * db_exist --
  *	Return if a line exists.
  *
- * PUBLIC: int db_exist __P((SCR *, recno_t));
+ * PUBLIC: int db_exist(SCR *, recno_t);
  */
 int
 db_exist(
@@ -509,7 +509,7 @@ db_exist(
  * db_last --
  *	Return the number of lines in the file.
  *
- * PUBLIC: int db_last __P((SCR *, recno_t *));
+ * PUBLIC: int db_last(SCR *, recno_t *);
  */
 int
 db_last(
@@ -583,7 +583,7 @@ alloc_err:
  * db_rget --
  *	Retrieve a raw line from database. No cache, no conversion.
  *
- * PUBLIC: int db_rget __P((SCR *, recno_t, char **, size_t *));
+ * PUBLIC: int db_rget(SCR *, recno_t, char **, size_t *);
  */
 int
 db_rget(
@@ -617,7 +617,7 @@ db_rget(
  * db_rset --
  *	Store a line in the file. No log, no conversion.
  *
- * PUBLIC: int db_rset __P((SCR *, recno_t, char *, size_t));
+ * PUBLIC: int db_rset(SCR *, recno_t, char *, size_t);
  */
 int
 db_rset(
@@ -649,7 +649,7 @@ db_rset(
  * db_err --
  *	Report a line error.
  *
- * PUBLIC: void db_err __P((SCR *, recno_t));
+ * PUBLIC: void db_err(SCR *, recno_t);
  */
 void
 db_err(

--- a/common/log.c
+++ b/common/log.c
@@ -63,13 +63,13 @@ static const char sccsid[] = "$Id: log.c,v 10.27 2011/07/13 06:25:50 zy Exp $";
  * behaved that way.
  */
 
-static int	log_cursor1 __P((SCR *, int));
-static void	log_err __P((SCR *, char *, int));
+static int	log_cursor1(SCR *, int);
+static void	log_err(SCR *, char *, int);
 #if defined(DEBUG) && 0
-static void	log_trace __P((SCR *, char *, recno_t, u_char *));
+static void	log_trace(SCR *, char *, recno_t, u_char *);
 #endif
-static int	apply_with __P((int (*)(SCR *, recno_t, CHAR_T *, size_t),
-					SCR *, recno_t, u_char *, size_t));
+static int	apply_with(int (*)(SCR *, recno_t, CHAR_T *, size_t),
+					SCR *, recno_t, u_char *, size_t);
 
 /* Try and restart the log on failure, i.e. if we run out of memory. */
 #define	LOG_ERR {							\
@@ -90,7 +90,7 @@ typedef struct {
  * log_init --
  *	Initialize the logging subsystem.
  *
- * PUBLIC: int log_init __P((SCR *, EXF *));
+ * PUBLIC: int log_init(SCR *, EXF *);
  */
 int
 log_init(
@@ -126,7 +126,7 @@ log_init(
  * log_end --
  *	Close the logging subsystem.
  *
- * PUBLIC: int log_end __P((SCR *, EXF *));
+ * PUBLIC: int log_end(SCR *, EXF *);
  */
 int
 log_end(
@@ -156,7 +156,7 @@ log_end(
  * log_cursor --
  *	Log the current cursor position, starting an event.
  *
- * PUBLIC: int log_cursor __P((SCR *));
+ * PUBLIC: int log_cursor(SCR *);
  */
 int
 log_cursor(SCR *sp)
@@ -221,7 +221,7 @@ log_cursor1(
  * log_line --
  *	Log a line change.
  *
- * PUBLIC: int log_line __P((SCR *, recno_t, u_int));
+ * PUBLIC: int log_line(SCR *, recno_t, u_int);
  */
 int
 log_line(
@@ -324,7 +324,7 @@ log_line(
  *	would mean that undo operations would only reset marks, and not
  *	cause any other change.
  *
- * PUBLIC: int log_mark __P((SCR *, LMARK *));
+ * PUBLIC: int log_mark(SCR *, LMARK *);
  */
 int
 log_mark(
@@ -370,7 +370,7 @@ log_mark(
  * Log_backward --
  *	Roll the log backward one operation.
  *
- * PUBLIC: int log_backward __P((SCR *, MARK *));
+ * PUBLIC: int log_backward(SCR *, MARK *);
  */
 int
 log_backward(
@@ -474,7 +474,7 @@ err:	F_CLR(ep, F_NOLOG);
  * then move back on and do a 'U', the line will be restored to the way
  * it was before the original change.
  *
- * PUBLIC: int log_setline __P((SCR *));
+ * PUBLIC: int log_setline(SCR *);
  */
 int
 log_setline(SCR *sp)
@@ -558,7 +558,7 @@ err:	F_CLR(ep, F_NOLOG);
  * Log_forward --
  *	Roll the log forward one operation.
  *
- * PUBLIC: int log_forward __P((SCR *, MARK *));
+ * PUBLIC: int log_forward(SCR *, MARK *);
  */
 int
 log_forward(

--- a/common/main.c
+++ b/common/main.c
@@ -30,15 +30,15 @@ static const char sccsid[] = "$Id: main.c,v 11.0 2012/10/17 06:34:37 zy Exp $";
 #include "../vi/vi.h"
 #include "pathnames.h"
 
-static void	 attach __P((GS *));
-static void	 v_estr __P((char *, int, char *));
-static int	 v_obsolete __P((char *, char *[]));
+static void	 attach(GS *);
+static void	 v_estr(char *, int, char *);
+static int	 v_obsolete(char *, char *[]);
 
 /*
  * editor --
  *	Main editor routine.
  *
- * PUBLIC: int editor __P((GS *, int, char *[]));
+ * PUBLIC: int editor(GS *, int, char *[]);
  */
 int
 editor(
@@ -428,7 +428,7 @@ err:		rval = 1;
  * v_end --
  *	End the program, discarding screens and most of the global area.
  *
- * PUBLIC: void v_end __P((GS *));
+ * PUBLIC: void v_end(GS *);
  */
 void
 v_end(gp)

--- a/common/mark.c
+++ b/common/mark.c
@@ -26,7 +26,7 @@ static const char sccsid[] = "$Id: mark.c,v 10.14 2011/07/04 14:42:58 zy Exp $";
 
 #include "common.h"
 
-static LMARK *mark_find __P((SCR *, ARG_CHAR_T));
+static LMARK *mark_find(SCR *, ARG_CHAR_T);
 
 /*
  * Marks are maintained in a key sorted singly linked list.  We can't
@@ -63,7 +63,7 @@ static LMARK *mark_find __P((SCR *, ARG_CHAR_T));
  * mark_init --
  *	Set up the marks.
  *
- * PUBLIC: int mark_init __P((SCR *, EXF *));
+ * PUBLIC: int mark_init(SCR *, EXF *);
  */
 int
 mark_init(
@@ -84,7 +84,7 @@ mark_init(
  * mark_end --
  *	Free up the marks.
  *
- * PUBLIC: int mark_end __P((SCR *, EXF *));
+ * PUBLIC: int mark_end(SCR *, EXF *);
  */
 int
 mark_end(
@@ -108,7 +108,7 @@ mark_end(
  * mark_get --
  *	Get the location referenced by a mark.
  *
- * PUBLIC: int mark_get __P((SCR *, ARG_CHAR_T, MARK *, mtype_t));
+ * PUBLIC: int mark_get(SCR *, ARG_CHAR_T, MARK *, mtype_t);
  */
 int
 mark_get(
@@ -153,7 +153,7 @@ mark_get(
  * mark_set --
  *	Set the location referenced by a mark.
  *
- * PUBLIC: int mark_set __P((SCR *, ARG_CHAR_T, MARK *, int));
+ * PUBLIC: int mark_set(SCR *, ARG_CHAR_T, MARK *, int);
  */
 int
 mark_set(
@@ -220,7 +220,7 @@ mark_find(
  * mark_insdel --
  *	Update the marks based on an insertion or deletion.
  *
- * PUBLIC: int mark_insdel __P((SCR *, lnop_t, recno_t));
+ * PUBLIC: int mark_insdel(SCR *, lnop_t, recno_t);
  */
 int
 mark_insdel(

--- a/common/msg.c
+++ b/common/msg.c
@@ -36,7 +36,7 @@ static const char sccsid[] = "$Id: msg.c,v 11.0 2012/10/17 06:34:37 zy Exp $";
  * msgq --
  *	Display a message.
  *
- * PUBLIC: void msgq __P((SCR *, mtype_t, const char *, ...));
+ * PUBLIC: void msgq(SCR *, mtype_t, const char *, ...);
  */
 void
 msgq(
@@ -356,7 +356,7 @@ alloc_err:
  * msgq_wstr --
  *	Display a message with an embedded string.
  *
- * PUBLIC: void msgq_wstr __P((SCR *, mtype_t, const CHAR_T *, const char *));
+ * PUBLIC: void msgq_wstr(SCR *, mtype_t, const CHAR_T *, const char *);
  */
 void
 msgq_wstr(
@@ -380,7 +380,7 @@ msgq_wstr(
  * msgq_str --
  *	Display a message with an embedded string.
  *
- * PUBLIC: void msgq_str __P((SCR *, mtype_t, const char *, const char *));
+ * PUBLIC: void msgq_str(SCR *, mtype_t, const char *, const char *);
  */
 void
 msgq_str(
@@ -423,7 +423,7 @@ msgq_str(
  * the command 2d}, from the 'b' would report that two lines were deleted,
  * not one.
  *
- * PUBLIC: void mod_rpt __P((SCR *));
+ * PUBLIC: void mod_rpt(SCR *);
  */
 void
 mod_rpt(SCR *sp)
@@ -533,7 +533,7 @@ alloc_err:
  * msgq_status --
  *	Report on the file's status.
  *
- * PUBLIC: void msgq_status __P((SCR *, recno_t, u_int));
+ * PUBLIC: void msgq_status(SCR *, recno_t, u_int);
  */
 void
 msgq_status(
@@ -705,7 +705,7 @@ alloc_err:
  * msg_open --
  *	Open the message catalogs.
  *
- * PUBLIC: int msg_open __P((SCR *, char *));
+ * PUBLIC: int msg_open(SCR *, char *);
  */
 int
 msg_open(
@@ -772,7 +772,7 @@ ret:	free(p);
  * msg_close --
  *	Close the message catalogs.
  *
- * PUBLIC: void msg_close __P((GS *));
+ * PUBLIC: void msg_close(GS *);
  */
 void
 msg_close(GS *gp)
@@ -785,7 +785,7 @@ msg_close(GS *gp)
  * msg_cont --
  *	Return common continuation messages.
  *
- * PUBLIC: const char *msg_cmsg __P((SCR *, cmsg_t, size_t *));
+ * PUBLIC: const char *msg_cmsg(SCR *, cmsg_t, size_t *);
  */
 const char *
 msg_cmsg(
@@ -823,7 +823,7 @@ msg_cmsg(
  * Only a single catalog message can be accessed at a time, if multiple
  * ones are needed, they must be copied into local memory.
  *
- * PUBLIC: const char *msg_cat __P((SCR *, const char *, size_t *));
+ * PUBLIC: const char *msg_cat(SCR *, const char *, size_t *);
  */
 const char *
 msg_cat(
@@ -861,7 +861,7 @@ msg_cat(
  * msg_print --
  *	Return a printable version of a string, in allocated memory.
  *
- * PUBLIC: char *msg_print __P((SCR *, const char *, int *));
+ * PUBLIC: char *msg_print(SCR *, const char *, int *);
  */
 char *
 msg_print(

--- a/common/options.c
+++ b/common/options.c
@@ -30,9 +30,9 @@ static const char sccsid[] = "$Id: options.c,v 10.73 2012/10/09 06:14:07 zy Exp 
 #include "../vi/vi.h"
 #include "pathnames.h"
 
-static int	 	 opts_abbcmp __P((const void *, const void *));
-static int	 	 opts_cmp __P((const void *, const void *));
-static int	 	 opts_print __P((SCR *, OPTLIST const *));
+static int	 	 opts_abbcmp(const void *, const void *);
+static int	 	 opts_cmp(const void *, const void *);
+static int	 	 opts_print(SCR *, OPTLIST const *);
 
 #ifdef USE_WIDECHAR
 #define OPT_WC	    0
@@ -294,7 +294,7 @@ static OABBREV const abbrev[] = {
  * opts_init --
  *	Initialize some of the options.
  *
- * PUBLIC: int opts_init __P((SCR *, int *));
+ * PUBLIC: int opts_init(SCR *, int *);
  */
 int
 opts_init(
@@ -460,7 +460,7 @@ err:	msgq_wstr(sp, M_ERR, optlist[optindx].name,
  * opts_set --
  *	Change the values of one or more options.
  *
- * PUBLIC: int opts_set __P((SCR *, ARGS *[], char *));
+ * PUBLIC: int opts_set(SCR *, ARGS *[], char *);
  */
 int
 opts_set(
@@ -754,7 +754,7 @@ badnum:				INT2CHAR(sp, name, STRLEN(name) + 1,
  * o_set --
  *	Set an option's value.
  *
- * PUBLIC: int o_set __P((SCR *, int, u_int, char *, u_long));
+ * PUBLIC: int o_set(SCR *, int, u_int, char *, u_long);
  */
 int
 o_set(
@@ -798,7 +798,7 @@ o_set(
  * opts_empty --
  *	Return 1 if the string option is invalid, 0 if it's OK.
  *
- * PUBLIC: int opts_empty __P((SCR *, int, int));
+ * PUBLIC: int opts_empty(SCR *, int, int);
  */
 int
 opts_empty(
@@ -821,7 +821,7 @@ opts_empty(
  * opts_dump --
  *	List the current values of selected options.
  *
- * PUBLIC: void opts_dump __P((SCR *, enum optdisp));
+ * PUBLIC: void opts_dump(SCR *, enum optdisp);
  */
 void
 opts_dump(
@@ -987,7 +987,7 @@ opts_print(
  * opts_save --
  *	Write the current configuration to a file.
  *
- * PUBLIC: int opts_save __P((SCR *, FILE *));
+ * PUBLIC: int opts_save(SCR *, FILE *);
  */
 int
 opts_save(
@@ -1045,7 +1045,7 @@ opts_save(
  * opts_search --
  *	Search for an option.
  *
- * PUBLIC: OPTLIST const *opts_search __P((CHAR_T *));
+ * PUBLIC: OPTLIST const *opts_search(CHAR_T *);
  */
 OPTLIST const *
 opts_search(CHAR_T *name)
@@ -1090,7 +1090,7 @@ opts_search(CHAR_T *name)
  * opts_nomatch --
  *	Standard nomatch error message for options.
  *
- * PUBLIC: void opts_nomatch __P((SCR *, CHAR_T *));
+ * PUBLIC: void opts_nomatch(SCR *, CHAR_T *);
  */
 void
 opts_nomatch(
@@ -1121,7 +1121,7 @@ opts_cmp(
  * opts_copy --
  *	Copy a screen's OPTION array.
  *
- * PUBLIC: int opts_copy __P((SCR *, SCR *));
+ * PUBLIC: int opts_copy(SCR *, SCR *);
  */
 int
 opts_copy(
@@ -1169,7 +1169,7 @@ nomem:			msgq(orig, M_SYSERR, NULL);
  * opts_free --
  *	Free all option strings
  *
- * PUBLIC: void opts_free __P((SCR *));
+ * PUBLIC: void opts_free(SCR *);
  */
 void
 opts_free(SCR *sp)

--- a/common/options.h
+++ b/common/options.h
@@ -78,7 +78,7 @@ struct _option {
 struct _optlist {
 	CHAR_T	*name;			/* Name. */
 					/* Change function. */
-	int	(*func) __P((SCR *, OPTION *, char *, u_long *));
+	int	(*func)(SCR *, OPTION *, char *, u_long *);
 					/* Type of object. */
 	enum { OPT_0BOOL, OPT_1BOOL, OPT_NUM, OPT_STR } type;
 

--- a/common/options_f.c
+++ b/common/options_f.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: options_f.c,v 10.34 04/07/11 16:06:29 zy Exp 
 #include "common.h"
 
 /*
- * PUBLIC: int f_altwerase __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_altwerase(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_altwerase(
@@ -44,7 +44,7 @@ f_altwerase(
 }
 
 /*
- * PUBLIC: int f_columns __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_columns(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_columns(
@@ -78,7 +78,7 @@ f_columns(
 }
 
 /*
- * PUBLIC: int f_lines __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_lines(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_lines(
@@ -135,7 +135,7 @@ f_lines(
 }
 
 /*
- * PUBLIC: int f_lisp __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_lisp(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_lisp(
@@ -149,7 +149,7 @@ f_lisp(
 }
 
 /*
- * PUBLIC: int f_msgcat __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_msgcat(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_msgcat(
@@ -163,7 +163,7 @@ f_msgcat(
 }
 
 /*
- * PUBLIC: int f_print __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_print(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_print(
@@ -192,7 +192,7 @@ f_print(
 }
 
 /*
- * PUBLIC: int f_readonly __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_readonly(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_readonly(
@@ -213,7 +213,7 @@ f_readonly(
 }
 
 /*
- * PUBLIC: int f_recompile __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_recompile(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_recompile(
@@ -234,7 +234,7 @@ f_recompile(
 }
 
 /*
- * PUBLIC: int f_reformat __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_reformat(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_reformat(
@@ -248,7 +248,7 @@ f_reformat(
 }
 
 /*
- * PUBLIC: int f_ttywerase __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_ttywerase(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_ttywerase(
@@ -263,7 +263,7 @@ f_ttywerase(
 }
 
 /*
- * PUBLIC: int f_w300 __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_w300(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_w300(
@@ -284,7 +284,7 @@ f_w300(
 }
 
 /*
- * PUBLIC: int f_w1200 __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_w1200(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_w1200(
@@ -305,7 +305,7 @@ f_w1200(
 }
 
 /*
- * PUBLIC: int f_w9600 __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_w9600(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_w9600(
@@ -326,7 +326,7 @@ f_w9600(
 }
 
 /*
- * PUBLIC: int f_window __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_window(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_window(
@@ -342,7 +342,7 @@ f_window(
 }
 
 /*
- * PUBLIC: int f_encoding __P((SCR *, OPTION *, char *, u_long *));
+ * PUBLIC: int f_encoding(SCR *, OPTION *, char *, u_long *);
  */
 int
 f_encoding(

--- a/common/put.c
+++ b/common/put.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: put.c,v 10.19 04/07/11 17:00:24 zy Exp $";
  * put --
  *	Put text buffer contents into the file.
  *
- * PUBLIC: int put __P((SCR *, CB *, CHAR_T *, MARK *, MARK *, int));
+ * PUBLIC: int put(SCR *, CB *, CHAR_T *, MARK *, MARK *, int);
  */
 int
 put(

--- a/common/recover.c
+++ b/common/recover.c
@@ -102,18 +102,18 @@ static const char sccsid[] = "$Id: recover.c,v 11.2 2012/10/09 08:06:58 zy Exp $
 
 #define	VI_DHEADER	"X-vi-data:"
 
-static int	 rcv_copy __P((SCR *, int, char *));
-static void	 rcv_email __P((SCR *, char *));
-static int	 rcv_mailfile __P((SCR *, int, char *));
-static int	 rcv_mktemp __P((SCR *, char *, char *));
-static int	 rcv_dlnwrite __P((SCR *, const char *, const char *, FILE *));
-static int	 rcv_dlnread __P((SCR *, char **, char **, FILE *));
+static int	 rcv_copy(SCR *, int, char *);
+static void	 rcv_email(SCR *, char *);
+static int	 rcv_mailfile(SCR *, int, char *);
+static int	 rcv_mktemp(SCR *, char *, char *);
+static int	 rcv_dlnwrite(SCR *, const char *, const char *, FILE *);
+static int	 rcv_dlnread(SCR *, char **, char **, FILE *);
 
 /*
  * rcv_tmp --
  *	Build a file name that will be used as the recovery file.
  *
- * PUBLIC: int rcv_tmp __P((SCR *, EXF *, char *));
+ * PUBLIC: int rcv_tmp(SCR *, EXF *, char *);
  */
 int
 rcv_tmp(
@@ -172,7 +172,7 @@ err:		msgq(sp, M_ERR,
  * rcv_init --
  *	Force the file to be snapshotted for recovery.
  *
- * PUBLIC: int rcv_init __P((SCR *));
+ * PUBLIC: int rcv_init(SCR *);
  */
 int
 rcv_init(SCR *sp)
@@ -234,7 +234,7 @@ err:	msgq(sp, M_ERR,
  *		sending email to the user if the file was modified
  *		ending the file session
  *
- * PUBLIC: int rcv_sync __P((SCR *, u_int));
+ * PUBLIC: int rcv_sync(SCR *, u_int);
  */
 int
 rcv_sync(
@@ -505,7 +505,7 @@ err:	if (!issync)
  * rcv_list --
  *	List the files that can be recovered by this user.
  *
- * PUBLIC: int rcv_list __P((SCR *));
+ * PUBLIC: int rcv_list(SCR *);
  */
 int
 rcv_list(SCR *sp)
@@ -612,7 +612,7 @@ next:		(void)fclose(fp);
  * rcv_read --
  *	Start a recovered file as the file to edit.
  *
- * PUBLIC: int rcv_read __P((SCR *, FREF *));
+ * PUBLIC: int rcv_read(SCR *, FREF *);
  */
 int
 rcv_read(

--- a/common/screen.c
+++ b/common/screen.c
@@ -32,7 +32,7 @@ static const char sccsid[] = "$Id: screen.c,v 10.25 2011/12/04 04:06:45 zy Exp $
  * screen_init --
  *	Do the default initialization of an SCR structure.
  *
- * PUBLIC: int screen_init __P((GS *, SCR *, SCR **));
+ * PUBLIC: int screen_init(GS *, SCR *, SCR **);
  */
 int
 screen_init(
@@ -129,7 +129,7 @@ err:	screen_end(sp);
  *	Release a screen, no matter what had (and had not) been
  *	initialized.
  *
- * PUBLIC: int screen_end __P((SCR *));
+ * PUBLIC: int screen_end(SCR *);
  */
 int
 screen_end(SCR *sp)
@@ -205,7 +205,7 @@ screen_end(SCR *sp)
  * screen_next --
  *	Return the next screen in the queue.
  *
- * PUBLIC: SCR *screen_next __P((SCR *));
+ * PUBLIC: SCR *screen_next(SCR *);
  */
 SCR *
 screen_next(SCR *sp)

--- a/common/search.c
+++ b/common/search.c
@@ -30,8 +30,8 @@ static const char sccsid[] = "$Id: search.c,v 10.26 2011/07/04 20:16:26 zy Exp $
 
 typedef enum { S_EMPTY, S_EOF, S_NOPREV, S_NOTFOUND, S_SOF, S_WRAP } smsg_t;
 
-static void	search_msg __P((SCR *, smsg_t));
-static int	search_init __P((SCR *, dir_t, CHAR_T *, size_t, CHAR_T **, u_int));
+static void	search_msg(SCR *, smsg_t);
+static int	search_init(SCR *, dir_t, CHAR_T *, size_t, CHAR_T **, u_int);
 
 /*
  * search_init --
@@ -142,8 +142,8 @@ prev:			if (sp->re == NULL) {
  * f_search --
  *	Do a forward search.
  *
- * PUBLIC: int f_search __P((SCR *,
- * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int));
+ * PUBLIC: int f_search(SCR *,
+ * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int);
  */
 int
 f_search(
@@ -288,8 +288,8 @@ f_search(
  * b_search --
  *	Do a backward search.
  *
- * PUBLIC: int b_search __P((SCR *,
- * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int));
+ * PUBLIC: int b_search(SCR *,
+ * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int);
  */
 int
 b_search(
@@ -487,7 +487,7 @@ search_msg(
  * search_busy --
  *	Put up the busy searching message.
  *
- * PUBLIC: void search_busy __P((SCR *, busy_t));
+ * PUBLIC: void search_busy(SCR *, busy_t);
  */
 void
 search_busy(

--- a/common/seq.c
+++ b/common/seq.c
@@ -31,8 +31,8 @@ static const char sccsid[] = "$Id: seq.c,v 10.18 2011/12/11 23:13:00 zy Exp $";
  * seq_set --
  *	Internal version to enter a sequence.
  *
- * PUBLIC: int seq_set __P((SCR *, CHAR_T *,
- * PUBLIC:    size_t, CHAR_T *, size_t, CHAR_T *, size_t, seq_t, int));
+ * PUBLIC: int seq_set(SCR *, CHAR_T *,
+ * PUBLIC:    size_t, CHAR_T *, size_t, CHAR_T *, size_t, seq_t, int);
  */
 int
 seq_set(
@@ -136,7 +136,7 @@ mem1:		errno = sv_errno;
  * seq_delete --
  *	Delete a sequence.
  *
- * PUBLIC: int seq_delete __P((SCR *, CHAR_T *, size_t, seq_t));
+ * PUBLIC: int seq_delete(SCR *, CHAR_T *, size_t, seq_t);
  */
 int
 seq_delete(
@@ -172,7 +172,7 @@ seq_delete(
  * seq_free --
  *	Free a map entry.
  *
- * PUBLIC: int seq_free __P((SEQ *));
+ * PUBLIC: int seq_free(SEQ *);
  */
 int
 seq_free(SEQ *qp)
@@ -193,7 +193,7 @@ seq_free(SEQ *qp)
  *	isn't NULL, partial matches count.
  *
  * PUBLIC: SEQ *seq_find
- * PUBLIC:    __P((SCR *, SEQ **, EVENT *, CHAR_T *, size_t, seq_t, int *));
+ * PUBLIC:   (SCR *, SEQ **, EVENT *, CHAR_T *, size_t, seq_t, int *);
  */
 SEQ *
 seq_find(
@@ -278,7 +278,7 @@ seq_find(
  * seq_close --
  *	Discard all sequences.
  *
- * PUBLIC: void seq_close __P((GS *));
+ * PUBLIC: void seq_close(GS *);
  */
 void
 seq_close(GS *gp)
@@ -295,7 +295,7 @@ seq_close(GS *gp)
  * seq_dump --
  *	Display the sequence entries of a specified type.
  *
- * PUBLIC: int seq_dump __P((SCR *, seq_t, int));
+ * PUBLIC: int seq_dump(SCR *, seq_t, int);
  */
 int
 seq_dump(
@@ -343,7 +343,7 @@ seq_dump(
  * seq_save --
  *	Save the sequence entries to a file.
  *
- * PUBLIC: int seq_save __P((SCR *, FILE *, char *, seq_t));
+ * PUBLIC: int seq_save(SCR *, FILE *, char *, seq_t);
  */
 int
 seq_save(
@@ -389,7 +389,7 @@ seq_save(
  * e_memcmp --
  *	Compare a string of EVENT's to a string of CHAR_T's.
  *
- * PUBLIC: int e_memcmp __P((CHAR_T *, EVENT *, size_t));
+ * PUBLIC: int e_memcmp(CHAR_T *, EVENT *, size_t);
  */
 int
 e_memcmp(

--- a/common/util.c
+++ b/common/util.c
@@ -39,7 +39,7 @@ static const char sccsid[] = "$Id: util.c,v 10.30 2013/03/19 10:00:27 yamt Exp $
  * binc --
  *	Increase the size of a buffer.
  *
- * PUBLIC: void *binc __P((SCR *, void *, size_t *, size_t));
+ * PUBLIC: void *binc(SCR *, void *, size_t *, size_t);
  */
 void *
 binc(
@@ -76,7 +76,7 @@ binc(
  *	including or after the starting column.  On error, set
  *	the column to 0, it's safest.
  *
- * PUBLIC: int nonblank __P((SCR *, recno_t, size_t *));
+ * PUBLIC: int nonblank(SCR *, recno_t, size_t *);
  */
 int
 nonblank(
@@ -112,7 +112,7 @@ nonblank(
  * tail --
  *	Return tail of a path.
  *
- * PUBLIC: char *tail __P((char *));
+ * PUBLIC: char *tail(char *);
  */
 char *
 tail(char *path)
@@ -128,7 +128,7 @@ tail(char *path)
  * join --
  *	Join two paths; need free.
  *
- * PUBLIC: char *join __P((char *, char *));
+ * PUBLIC: char *join(char *, char *);
  */
 char *
 join(
@@ -148,7 +148,7 @@ join(
  * expanduser --
  *	Return a "~" or "~user" expanded path; need free.
  *
- * PUBLIC: char *expanduser __P((char *));
+ * PUBLIC: char *expanduser(char *);
  */
 char *
 expanduser(char *str)
@@ -198,7 +198,7 @@ expanduser(char *str)
  * quote --
  *	Return a escaped string for /bin/sh; need free.
  *
- * PUBLIC: char *quote __P((char *));
+ * PUBLIC: char *quote(char *);
  */
 char *
 quote(char *str)
@@ -245,7 +245,7 @@ quote(char *str)
  * v_strdup --
  *	Strdup for 8-bit character strings with an associated length.
  *
- * PUBLIC: char *v_strdup __P((SCR *, const char *, size_t));
+ * PUBLIC: char *v_strdup(SCR *, const char *, size_t);
  */
 char *
 v_strdup(
@@ -267,7 +267,7 @@ v_strdup(
  * v_wstrdup --
  *	Strdup for wide character strings with an associated length.
  *
- * PUBLIC: CHAR_T *v_wstrdup __P((SCR *, const CHAR_T *, size_t));
+ * PUBLIC: CHAR_T *v_wstrdup(SCR *, const CHAR_T *, size_t);
  */
 CHAR_T *
 v_wstrdup(SCR *sp,
@@ -288,7 +288,7 @@ v_wstrdup(SCR *sp,
  * nget_uslong --
  *      Get an unsigned long, checking for overflow.
  *
- * PUBLIC: enum nresult nget_uslong __P((u_long *, const CHAR_T *, CHAR_T **, int));
+ * PUBLIC: enum nresult nget_uslong(u_long *, const CHAR_T *, CHAR_T **, int);
  */
 enum nresult
 nget_uslong(
@@ -310,7 +310,7 @@ nget_uslong(
  * nget_slong --
  *      Convert a signed long, checking for overflow and underflow.
  *
- * PUBLIC: enum nresult nget_slong __P((long *, const CHAR_T *, CHAR_T **, int));
+ * PUBLIC: enum nresult nget_slong(long *, const CHAR_T *, CHAR_T **, int);
  */
 enum nresult
 nget_slong(
@@ -336,7 +336,7 @@ nget_slong(
  * timepoint_steady --
  *      Get a timestamp from a monotonic clock.
  *
- * PUBLIC: void timepoint_steady __P((struct timespec *));
+ * PUBLIC: void timepoint_steady(struct timespec *);
  */
 void
 timepoint_steady(
@@ -367,7 +367,7 @@ timepoint_steady(
  * timepoint_system --
  *      Get the current calendar time.
  *
- * PUBLIC: void timepoint_system __P((struct timespec *));
+ * PUBLIC: void timepoint_system(struct timespec *);
  */
 void
 timepoint_system(
@@ -401,7 +401,7 @@ timepoint_system(
  * TRACE --
  *	debugging trace routine.
  *
- * PUBLIC: void TRACE __P((SCR *, const char *, ...));
+ * PUBLIC: void TRACE(SCR *, const char *, ...);
  */
 void
 TRACE(

--- a/ex/ex.c
+++ b/ex/ex.c
@@ -31,20 +31,20 @@ static const char sccsid[] = "$Id: ex.c,v 10.80 2012/10/03 16:24:40 zy Exp $";
 #include "../vi/vi.h"
 
 #if defined(DEBUG) && defined(COMLOG)
-static void	ex_comlog __P((SCR *, EXCMD *));
+static void	ex_comlog(SCR *, EXCMD *);
 #endif
 static EXCMDLIST const *
-		ex_comm_search __P((CHAR_T *, size_t));
-static int	ex_discard __P((SCR *));
-static int	ex_line __P((SCR *, EXCMD *, MARK *, int *, int *));
-static int	ex_load __P((SCR *));
-static void	ex_unknown __P((SCR *, CHAR_T *, size_t));
+		ex_comm_search(CHAR_T *, size_t);
+static int	ex_discard(SCR *);
+static int	ex_line(SCR *, EXCMD *, MARK *, int *, int *);
+static int	ex_load(SCR *);
+static void	ex_unknown(SCR *, CHAR_T *, size_t);
 
 /*
  * ex --
  *	Main ex loop.
  *
- * PUBLIC: int ex __P((SCR **));
+ * PUBLIC: int ex(SCR **);
  */
 int
 ex(SCR **spp)
@@ -187,7 +187,7 @@ ex(SCR **spp)
  *
  * For extra credit, try them in a startup .exrc file.
  *
- * PUBLIC: int ex_cmd __P((SCR *));
+ * PUBLIC: int ex_cmd(SCR *);
  */
 int
 ex_cmd(SCR *sp)
@@ -1616,7 +1616,7 @@ rsuccess:	tmp = 0;
  * ex_range --
  *	Get a line range for ex commands, or perform a vi ex address search.
  *
- * PUBLIC: int ex_range __P((SCR *, EXCMD *, int *));
+ * PUBLIC: int ex_range(SCR *, EXCMD *, int *);
  */
 int
 ex_range(SCR *sp, EXCMD *ecp, int *errp)
@@ -1825,7 +1825,7 @@ ex_line(SCR *sp, EXCMD *ecp, MARK *mp, int *isaddrp, int *errp)
 	GS *gp;
 	long total, val;
 	int isneg;
-	int (*sf) __P((SCR *, MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int));
+	int (*sf)(SCR *, MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int);
 	CHAR_T *endp;
 
 	gp = sp->gp;
@@ -2219,7 +2219,7 @@ alloc_err:
  *	[un]abbreviate command, so it can turn off abbreviations.  See
  *	the usual ranting in the vi/v_txt_ev.c:txt_abbrev() routine.
  *
- * PUBLIC: int ex_is_abbrev __P((CHAR_T *, size_t));
+ * PUBLIC: int ex_is_abbrev(CHAR_T *, size_t);
  */
 int
 ex_is_abbrev(CHAR_T *name, size_t len)
@@ -2236,7 +2236,7 @@ ex_is_abbrev(CHAR_T *name, size_t len)
  *	unmap command, so it can turn off input mapping.  See the usual
  *	ranting in the vi/v_txt_ev.c:txt_unmap() routine.
  *
- * PUBLIC: int ex_is_unmap __P((CHAR_T *, size_t));
+ * PUBLIC: int ex_is_unmap(CHAR_T *, size_t);
  */
 int
 ex_is_unmap(CHAR_T *name, size_t len)
@@ -2279,7 +2279,7 @@ ex_comm_search(CHAR_T *name, size_t len)
  *	Display a bad address message.
  *
  * PUBLIC: void ex_badaddr
- * PUBLIC:    __P((SCR *, EXCMDLIST const *, enum badaddr, enum nresult));
+ * PUBLIC:   (SCR *, EXCMDLIST const *, enum badaddr, enum nresult);
  */
 void
 ex_badaddr(SCR *sp, const EXCMDLIST *cp, enum badaddr ba, enum nresult nret)

--- a/ex/ex.h
+++ b/ex/ex.h
@@ -13,7 +13,7 @@
 
 typedef struct _excmdlist {		/* Ex command table structure. */
 	CHAR_T *name;			/* Command name, underlying function. */
-	int (*fn) __P((SCR *, EXCMD *));
+	int (*fn)(SCR *, EXCMD *);
 
 #define	E_ADDR1		0x00000001	/* One address. */
 #define	E_ADDR2		0x00000002	/* Two addresses. */

--- a/ex/ex_abbrev.c
+++ b/ex/ex_abbrev.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_abbrev.c,v 10.10 2001/12/16 18:18:54 skimo
  * ex_abbr -- :abbreviate [key replacement]
  *	Create an abbreviation or display abbreviations.
  *
- * PUBLIC: int ex_abbr __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_abbr(SCR *, EXCMD *);
  */
 int
 ex_abbr(SCR *sp, EXCMD *cmdp)
@@ -95,7 +95,7 @@ ex_abbr(SCR *sp, EXCMD *cmdp)
  * ex_unabbr -- :unabbreviate key
  *      Delete an abbreviation.
  *
- * PUBLIC: int ex_unabbr __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_unabbr(SCR *, EXCMD *);
  */
 int
 ex_unabbr(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_append.c
+++ b/ex/ex_append.c
@@ -27,14 +27,14 @@ static const char sccsid[] = "$Id: ex_append.c,v 10.34 2001/06/25 15:19:14 skimo
 
 enum which {APPEND, CHANGE, INSERT};
 
-static int ex_aci __P((SCR *, EXCMD *, enum which));
+static int ex_aci(SCR *, EXCMD *, enum which);
 
 /*
  * ex_append -- :[line] a[ppend][!]
  *	Append one or more lines of new text after the specified line,
  *	or the current line if no address is specified.
  *
- * PUBLIC: int ex_append __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_append(SCR *, EXCMD *);
  */
 int
 ex_append(SCR *sp, EXCMD *cmdp)
@@ -46,7 +46,7 @@ ex_append(SCR *sp, EXCMD *cmdp)
  * ex_change -- :[line[,line]] c[hange][!] [count]
  *	Change one or more lines to the input text.
  *
- * PUBLIC: int ex_change __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_change(SCR *, EXCMD *);
  */
 int
 ex_change(SCR *sp, EXCMD *cmdp)
@@ -59,7 +59,7 @@ ex_change(SCR *sp, EXCMD *cmdp)
  *	Insert one or more lines of new text before the specified line,
  *	or the current line if no address is specified.
  *
- * PUBLIC: int ex_insert __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_insert(SCR *, EXCMD *);
  */
 int
 ex_insert(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_args.c
+++ b/ex/ex_args.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_args.c,v 10.19 2011/12/16 16:18:10 zy Exp 
 #include "../common/common.h"
 #include "../vi/vi.h"
 
-static int ex_N_next __P((SCR *, EXCMD *));
+static int ex_N_next(SCR *, EXCMD *);
 
 /*
  * ex_next -- :next [+cmd] [files]
@@ -39,7 +39,7 @@ static int ex_N_next __P((SCR *, EXCMD *));
  * idea was that it ignored the force flag if the autowrite flag was
  * set.  This implementation handles them all identically.
  *
- * PUBLIC: int ex_next __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_next(SCR *, EXCMD *);
  */
 int
 ex_next(SCR *sp, EXCMD *cmdp)
@@ -171,7 +171,7 @@ ex_N_next(SCR *sp, EXCMD *cmdp)
  * ex_prev -- :prev
  *	Edit the previous file.
  *
- * PUBLIC: int ex_prev __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_prev(SCR *, EXCMD *);
  */
 int
 ex_prev(SCR *sp, EXCMD *cmdp)
@@ -220,7 +220,7 @@ ex_prev(SCR *sp, EXCMD *cmdp)
  * anyone noticing, but if they do, we'll have to put information into the SCR
  * structure so we can keep track of it.
  *
- * PUBLIC: int ex_rew __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_rew(SCR *, EXCMD *);
  */
 int
 ex_rew(SCR *sp, EXCMD *cmdp)
@@ -258,7 +258,7 @@ ex_rew(SCR *sp, EXCMD *cmdp)
  * ex_args -- :args
  *	Display the list of files.
  *
- * PUBLIC: int ex_args __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_args(SCR *, EXCMD *);
  */
 int
 ex_args(SCR *sp, EXCMD *cmdp)
@@ -299,7 +299,7 @@ ex_args(SCR *sp, EXCMD *cmdp)
  * ex_buildargv --
  *	Build a new file argument list.
  *
- * PUBLIC: char **ex_buildargv __P((SCR *, EXCMD *, char *));
+ * PUBLIC: char **ex_buildargv(SCR *, EXCMD *, char *);
  */
 char **
 ex_buildargv(SCR *sp, EXCMD *cmdp, char *name)

--- a/ex/ex_argv.c
+++ b/ex/ex_argv.c
@@ -30,18 +30,18 @@ static const char sccsid[] = "$Id: ex_argv.c,v 11.2 2012/10/09 23:00:29 zy Exp $
 
 #include "../common/common.h"
 
-static int argv_alloc __P((SCR *, size_t));
-static int argv_comp __P((const void *, const void *));
-static int argv_fexp __P((SCR *, EXCMD *,
-	CHAR_T *, size_t, CHAR_T *, size_t *, CHAR_T **, size_t *, int));
-static int argv_sexp __P((SCR *, CHAR_T **, size_t *, size_t *));
-static int argv_flt_user __P((SCR *, EXCMD *, CHAR_T *, size_t));
+static int argv_alloc(SCR *, size_t);
+static int argv_comp(const void *, const void *);
+static int argv_fexp(SCR *, EXCMD *,
+	CHAR_T *, size_t, CHAR_T *, size_t *, CHAR_T **, size_t *, int);
+static int argv_sexp(SCR *, CHAR_T **, size_t *, size_t *);
+static int argv_flt_user(SCR *, EXCMD *, CHAR_T *, size_t);
 
 /*
  * argv_init --
  *	Build  a prototype arguments list.
  *
- * PUBLIC: int argv_init __P((SCR *, EXCMD *));
+ * PUBLIC: int argv_init(SCR *, EXCMD *);
  */
 int
 argv_init(SCR *sp, EXCMD *excp)
@@ -61,7 +61,7 @@ argv_init(SCR *sp, EXCMD *excp)
  * argv_exp0 --
  *	Append a string to the argument list.
  *
- * PUBLIC: int argv_exp0 __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: int argv_exp0(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 int
 argv_exp0(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
@@ -84,7 +84,7 @@ argv_exp0(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
  *	Do file name expansion on a string, and append it to the
  *	argument list.
  *
- * PUBLIC: int argv_exp1 __P((SCR *, EXCMD *, CHAR_T *, size_t, int));
+ * PUBLIC: int argv_exp1(SCR *, EXCMD *, CHAR_T *, size_t, int);
  */
 int
 argv_exp1(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen, int is_bang)
@@ -123,7 +123,7 @@ ret:	FREE_SPACEW(sp, bp, blen);
  *	Do file name and shell expansion on a string, and append it to
  *	the argument list.
  *
- * PUBLIC: int argv_exp2 __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: int argv_exp2(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 int
 argv_exp2(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
@@ -209,7 +209,7 @@ err:	FREE_SPACEW(sp, bp, blen);
  *	Take a string and break it up into an argv, which is appended
  *	to the argument list.
  *
- * PUBLIC: int argv_exp3 __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: int argv_exp3(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 int
 argv_exp3(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
@@ -277,7 +277,7 @@ argv_exp3(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
  *	Filter the ex commands with a prefix, and append the results to
  *	the argument list.
  *
- * PUBLIC: int argv_flt_ex __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: int argv_flt_ex(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 int
 argv_flt_ex(SCR *sp, EXCMD *excp, CHAR_T *cmd, size_t cmdlen)
@@ -520,7 +520,7 @@ mem:			msgq(sp, M_SYSERR, NULL);
  * argv_free --
  *	Free up argument structures.
  *
- * PUBLIC: int argv_free __P((SCR *));
+ * PUBLIC: int argv_free(SCR *);
  */
 int
 argv_free(SCR *sp)
@@ -550,7 +550,7 @@ argv_free(SCR *sp)
  *	Find all file names matching the prefix and append them to the
  *	argument list.
  *
- * PUBLIC: int argv_flt_path __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: int argv_flt_path(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 int
 argv_flt_path(SCR *sp, EXCMD *excp, CHAR_T *path, size_t plen)
@@ -812,7 +812,7 @@ alloc_err:	rval = SEXP_ERR;
  * argv_esc --
  *	Escape a string into an ex and shell argument.
  *
- * PUBLIC: CHAR_T *argv_esc __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: CHAR_T *argv_esc(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 CHAR_T *
 argv_esc(SCR *sp, EXCMD *excp, CHAR_T *str, size_t len)
@@ -875,7 +875,7 @@ alloc_err:
  * argv_uesc --
  *	Unescape an escaped ex and shell argument.
  *
- * PUBLIC: CHAR_T *argv_uesc __P((SCR *, EXCMD *, CHAR_T *, size_t));
+ * PUBLIC: CHAR_T *argv_uesc(SCR *, EXCMD *, CHAR_T *, size_t);
  */
 CHAR_T *
 argv_uesc(SCR *sp, EXCMD *excp, CHAR_T *str, size_t len)

--- a/ex/ex_at.c
+++ b/ex/ex_at.c
@@ -32,7 +32,7 @@ static const char sccsid[] = "$Id: ex_at.c,v 10.16 2001/06/25 15:19:14 skimo Exp
  *
  *	Execute the contents of the buffer.
  *
- * PUBLIC: int ex_at __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_at(SCR *, EXCMD *);
  */
 int
 ex_at(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_bang.c
+++ b/ex/ex_bang.c
@@ -44,7 +44,7 @@ static const char sccsid[] = "$Id: ex_bang.c,v 10.36 2001/06/25 15:19:14 skimo E
  * ways of getting here display the right things.  It took a long time to
  * get it right (wrong?), so be careful.
  *
- * PUBLIC: int ex_bang __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_bang(SCR *, EXCMD *);
  */
 int
 ex_bang(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_cd.c
+++ b/ex/ex_cd.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_cd.c,v 10.13 2012/04/12 06:28:27 zy Exp $"
  * ex_cd -- :cd[!] [directory]
  *	Change directories.
  *
- * PUBLIC: int ex_cd __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_cd(SCR *, EXCMD *);
  */
 int
 ex_cd(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_cscope.c
+++ b/ex/ex_cscope.c
@@ -61,15 +61,15 @@ find c|d|e|f|g|i|s|t buffer|pattern\n\
       s: find all uses of name\n\
       t: find assignments to name"
 
-static int cscope_add __P((SCR *, EXCMD *, CHAR_T *));
-static int cscope_find __P((SCR *, EXCMD*, CHAR_T *));
-static int cscope_help __P((SCR *, EXCMD *, CHAR_T *));
-static int cscope_kill __P((SCR *, EXCMD *, CHAR_T *));
-static int cscope_reset __P((SCR *, EXCMD *, CHAR_T *));
+static int cscope_add(SCR *, EXCMD *, CHAR_T *);
+static int cscope_find(SCR *, EXCMD*, CHAR_T *);
+static int cscope_help(SCR *, EXCMD *, CHAR_T *);
+static int cscope_kill(SCR *, EXCMD *, CHAR_T *);
+static int cscope_reset(SCR *, EXCMD *, CHAR_T *);
 
 typedef struct _cc {
 	char	 *name;
-	int	(*function) __P((SCR *, EXCMD *, CHAR_T *));
+	int	(*function)(SCR *, EXCMD *, CHAR_T *);
 	char	 *help_msg;
 	char	 *usage_msg;
 } CC;
@@ -88,23 +88,23 @@ static CC const cscope_cmds[] = {
 	{ NULL }
 };
 
-static TAGQ	*create_cs_cmd __P((SCR *, char *, size_t *));
-static int	 csc_help __P((SCR *, char *));
-static void	 csc_file __P((SCR *,
-		    CSC *, char *, char **, size_t *, int *));
-static int	 get_paths __P((SCR *, CSC *));
-static CC const	*lookup_ccmd __P((char *));
-static int	 parse __P((SCR *, CSC *, TAGQ *, int *));
-static int	 read_prompt __P((SCR *, CSC *));
-static int	 run_cscope __P((SCR *, CSC *, char *));
-static int	 start_cscopes __P((SCR *, EXCMD *));
-static int	 terminate __P((SCR *, CSC *, int));
+static TAGQ	*create_cs_cmd(SCR *, char *, size_t *);
+static int	 csc_help(SCR *, char *);
+static void	 csc_file(SCR *,
+		    CSC *, char *, char **, size_t *, int *);
+static int	 get_paths(SCR *, CSC *);
+static CC const	*lookup_ccmd(char *);
+static int	 parse(SCR *, CSC *, TAGQ *, int *);
+static int	 read_prompt(SCR *, CSC *);
+static int	 run_cscope(SCR *, CSC *, char *);
+static int	 start_cscopes(SCR *, EXCMD *);
+static int	 terminate(SCR *, CSC *, int);
 
 /*
  * ex_cscope --
  *	Perform an ex cscope.
  *
- * PUBLIC: int ex_cscope __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_cscope(SCR *, EXCMD *);
  */
 int
 ex_cscope(SCR *sp, EXCMD *cmdp)
@@ -965,7 +965,7 @@ cscope_reset(SCR *sp, EXCMD *cmdp, CHAR_T *notusedp)
  * cscope_end --
  *	End all cscope connections.
  *
- * PUBLIC: int cscope_end __P((SCR *));
+ * PUBLIC: int cscope_end(SCR *);
  */
 int
 cscope_end(SCR *sp)
@@ -982,7 +982,7 @@ cscope_end(SCR *sp)
  * cscope_display --
  *	Display current connections.
  *
- * PUBLIC: int cscope_display __P((SCR *));
+ * PUBLIC: int cscope_display(SCR *);
  */
 int
 cscope_display(SCR *sp)
@@ -1006,7 +1006,7 @@ cscope_display(SCR *sp)
  * cscope_search --
  *	Search a file for a cscope entry.
  *
- * PUBLIC: int cscope_search __P((SCR *, TAGQ *, TAG *));
+ * PUBLIC: int cscope_search(SCR *, TAGQ *, TAG *);
  */
 int
 cscope_search(SCR *sp, TAGQ *tqp, TAG *tp)

--- a/ex/ex_delete.c
+++ b/ex/ex_delete.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: ex_delete.c,v 10.11 2001/06/25 15:19:15 skimo
  *
  *	Delete lines from the file.
  *
- * PUBLIC: int ex_delete __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_delete(SCR *, EXCMD *);
  */
 int
 ex_delete(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_display.c
+++ b/ex/ex_display.c
@@ -26,16 +26,16 @@ static const char sccsid[] = "$Id: ex_display.c,v 10.15 2001/06/25 15:19:15 skim
 #include "../common/common.h"
 #include "tag.h"
 
-static int	is_prefix __P((ARGS *, CHAR_T *));
-static int	bdisplay __P((SCR *));
-static void	db __P((SCR *, CB *, const char *));
+static int	is_prefix(ARGS *, CHAR_T *);
+static int	bdisplay(SCR *);
+static void	db(SCR *, CB *, const char *);
 
 /*
  * ex_display -- :display b[uffers] | c[onnections] | s[creens] | t[ags]
  *
  *	Display cscope connections, buffers, tags or screens.
  *
- * PUBLIC: int ex_display __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_display(SCR *, EXCMD *);
  */
 int
 ex_display(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_edit.c
+++ b/ex/ex_edit.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_edit.c,v 10.15 2011/12/22 23:26:50 zy Exp 
 #include "../common/common.h"
 #include "../vi/vi.h"
 
-static int ex_N_edit __P((SCR *, EXCMD *, FREF *, int));
+static int ex_N_edit(SCR *, EXCMD *, FREF *, int);
 
 /*
  * ex_edit --	:e[dit][!] [+cmd] [file]
@@ -43,7 +43,7 @@ static int ex_N_edit __P((SCR *, EXCMD *, FREF *, int));
  * a file name as well.  This seems unreasonable, so we support it
  * regardless.
  *
- * PUBLIC: int ex_edit __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_edit(SCR *, EXCMD *);
  */
 int
 ex_edit(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_equal.c
+++ b/ex/ex_equal.c
@@ -26,7 +26,7 @@ static const char sccsid[] = "$Id: ex_equal.c,v 10.12 2001/06/25 15:19:15 skimo 
 /*
  * ex_equal -- :address =
  *
- * PUBLIC: int ex_equal __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_equal(SCR *, EXCMD *);
  */
 int
 ex_equal(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_file.c
+++ b/ex/ex_file.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: ex_file.c,v 10.14 2001/06/25 15:19:16 skimo E
  * ex_file -- :f[ile] [name]
  *	Change the file's name and display the status line.
  *
- * PUBLIC: int ex_file __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_file(SCR *, EXCMD *);
  */
 int
 ex_file(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_filter.c
+++ b/ex/ex_filter.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_filter.c,v 10.44 2003/11/05 17:11:54 skimo
 
 #include "../common/common.h"
 
-static int filter_ldisplay __P((SCR *, FILE *));
+static int filter_ldisplay(SCR *, FILE *);
 
 /*
  * ex_filter --
@@ -35,8 +35,8 @@ static int filter_ldisplay __P((SCR *, FILE *));
  *	replace the original text with the stdout/stderr output of
  *	the utility.
  *
- * PUBLIC: int ex_filter __P((SCR *, 
- * PUBLIC:    EXCMD *, MARK *, MARK *, MARK *, CHAR_T *, enum filtertype));
+ * PUBLIC: int ex_filter(SCR *, 
+ * PUBLIC:    EXCMD *, MARK *, MARK *, MARK *, CHAR_T *, enum filtertype);
  */
 int
 ex_filter(SCR *sp, EXCMD *cmdp, MARK *fm, MARK *tm, MARK *rp, CHAR_T *cmd, enum filtertype ftype)

--- a/ex/ex_global.c
+++ b/ex/ex_global.c
@@ -30,13 +30,13 @@ static const char sccsid[] = "$Id: ex_global.c,v 10.32 2011/12/26 23:37:01 zy Ex
 
 enum which {GLOBAL, V};
 
-static int ex_g_setup __P((SCR *, EXCMD *, enum which));
+static int ex_g_setup(SCR *, EXCMD *, enum which);
 
 /*
  * ex_global -- [line [,line]] g[lobal][!] /pattern/ [commands]
  *	Exec on lines matching a pattern.
  *
- * PUBLIC: int ex_global __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_global(SCR *, EXCMD *);
  */
 int
 ex_global(SCR *sp, EXCMD *cmdp)
@@ -49,7 +49,7 @@ ex_global(SCR *sp, EXCMD *cmdp)
  * ex_v -- [line [,line]] v /pattern/ [commands]
  *	Exec on lines not matching a pattern.
  *
- * PUBLIC: int ex_v __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_v(SCR *, EXCMD *);
  */
 int
 ex_v(SCR *sp, EXCMD *cmdp)
@@ -248,7 +248,7 @@ usage:		ex_emsg(sp, cmdp->cmd->usage, EXM_USAGE);
  * ex_g_insdel --
  *	Update the ranges based on an insertion or deletion.
  *
- * PUBLIC: int ex_g_insdel __P((SCR *, lnop_t, recno_t));
+ * PUBLIC: int ex_g_insdel(SCR *, lnop_t, recno_t);
  */
 int
 ex_g_insdel(SCR *sp, lnop_t op, recno_t lno)

--- a/ex/ex_init.c
+++ b/ex/ex_init.c
@@ -30,15 +30,15 @@ static const char sccsid[] = "$Id: ex_init.c,v 10.33 2012/04/11 19:12:34 zy Exp 
 #include "pathnames.h"
 
 enum rc { NOEXIST, NOPERM, RCOK };
-static enum rc	exrc_isok __P((SCR *, struct stat *, char *, int, int));
+static enum rc	exrc_isok(SCR *, struct stat *, char *, int, int);
 
-static int ex_run_file __P((SCR *, char *));
+static int ex_run_file(SCR *, char *);
 
 /*
  * ex_screen_copy --
  *	Copy ex screen.
  *
- * PUBLIC: int ex_screen_copy __P((SCR *, SCR *));
+ * PUBLIC: int ex_screen_copy(SCR *, SCR *);
  */
 int
 ex_screen_copy(SCR *orig, SCR *sp)
@@ -74,7 +74,7 @@ ex_screen_copy(SCR *orig, SCR *sp)
  * ex_screen_end --
  *	End a vi screen.
  *
- * PUBLIC: int ex_screen_end __P((SCR *));
+ * PUBLIC: int ex_screen_end(SCR *);
  */
 int
 ex_screen_end(SCR *sp)
@@ -120,7 +120,7 @@ ex_screen_end(SCR *sp)
  * ex_optchange --
  *	Handle change of options for ex.
  *
- * PUBLIC: int ex_optchange __P((SCR *, int, char *, u_long *));
+ * PUBLIC: int ex_optchange(SCR *, int, char *, u_long *);
  */
 int
 ex_optchange(SCR *sp, int offset, char *str, u_long *valp)
@@ -137,7 +137,7 @@ ex_optchange(SCR *sp, int offset, char *str, u_long *valp)
  *	Read the EXINIT environment variable and the startup exrc files,
  *	and execute their commands.
  *
- * PUBLIC: int ex_exrc __P((SCR *));
+ * PUBLIC: int ex_exrc(SCR *);
  */
 int
 ex_exrc(SCR *sp)
@@ -281,7 +281,7 @@ ex_run_file(SCR *sp, char *name)
  * ex_run_str --
  *	Set up a string of ex commands to run.
  *
- * PUBLIC: int ex_run_str __P((SCR *, char *, CHAR_T *, size_t, int, int));
+ * PUBLIC: int ex_run_str(SCR *, char *, CHAR_T *, size_t, int, int);
  */
 int
 ex_run_str(SCR *sp, char *name, CHAR_T *str, size_t len, int ex_flags, int nocopy)

--- a/ex/ex_join.c
+++ b/ex/ex_join.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: ex_join.c,v 10.17 2004/03/16 14:14:04 skimo E
  * ex_join -- :[line [,line]] j[oin][!] [count] [flags]
  *	Join lines.
  *
- * PUBLIC: int ex_join __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_join(SCR *, EXCMD *);
  */
 int
 ex_join(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_map.c
+++ b/ex/ex_map.c
@@ -40,7 +40,7 @@ static const char sccsid[] = "$Id: ex_map.c,v 10.11 2001/06/25 15:19:17 skimo Ex
  *	put the map in a .exrc file, things would often work much better.
  *	No clue why.
  *
- * PUBLIC: int ex_map __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_map(SCR *, EXCMD *);
  */
 int
 ex_map(SCR *sp, EXCMD *cmdp)
@@ -103,7 +103,7 @@ nofunc:	if (stype == SEQ_COMMAND && input[1] == '\0')
  * ex_unmap -- (:unmap[!] key)
  *	Unmap a key.
  *
- * PUBLIC: int ex_unmap __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_unmap(SCR *, EXCMD *);
  */
 int
 ex_unmap(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_mark.c
+++ b/ex/ex_mark.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: ex_mark.c,v 10.9 2001/06/25 15:19:17 skimo Ex
  *	Mark lines.
  *
  *
- * PUBLIC: int ex_mark __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_mark(SCR *, EXCMD *);
  */
 int
 ex_mark(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_mkexrc.c
+++ b/ex/ex_mkexrc.c
@@ -34,7 +34,7 @@ static const char sccsid[] = "$Id: ex_mkexrc.c,v 10.13 2001/06/25 15:19:17 skimo
  *
  * Create (or overwrite) a .exrc file with the current info.
  *
- * PUBLIC: int ex_mkexrc __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_mkexrc(SCR *, EXCMD *);
  */
 int
 ex_mkexrc(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_move.c
+++ b/ex/ex_move.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: ex_move.c,v 10.16 2012/02/11 15:52:33 zy Exp 
  * ex_copy -- :[line [,line]] co[py] line [flags]
  *	Copy selected lines.
  *
- * PUBLIC: int ex_copy __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_copy(SCR *, EXCMD *);
  */
 int
 ex_copy(SCR *sp, EXCMD *cmdp)
@@ -81,7 +81,7 @@ err:	text_lfree(cb.textq);
  * ex_move -- :[line [,line]] mo[ve] line
  *	Move selected lines.
  *
- * PUBLIC: int ex_move __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_move(SCR *, EXCMD *);
  */
 int
 ex_move(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_open.c
+++ b/ex/ex_open.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: ex_open.c,v 10.8 2001/06/25 15:19:17 skimo Ex
  *
  *	Switch to single line "open" mode.
  *
- * PUBLIC: int ex_open __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_open(SCR *, EXCMD *);
  */
 int
 ex_open(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_preserve.c
+++ b/ex/ex_preserve.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: ex_preserve.c,v 10.15 2001/06/25 15:19:18 ski
  * ex_preserve -- :pre[serve]
  *	Push the file to recovery.
  *
- * PUBLIC: int ex_preserve __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_preserve(SCR *, EXCMD *);
  */
 int
 ex_preserve(SCR *sp, EXCMD *cmdp)
@@ -63,7 +63,7 @@ ex_preserve(SCR *sp, EXCMD *cmdp)
  * ex_recover -- :rec[over][!] file
  *	Recover the file.
  *
- * PUBLIC: int ex_recover __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_recover(SCR *, EXCMD *);
  */
 int
 ex_recover(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_print.c
+++ b/ex/ex_print.c
@@ -26,15 +26,15 @@ static const char sccsid[] = "$Id: ex_print.c,v 10.26 2013/11/02 02:11:07 zy Exp
 
 #include "../common/common.h"
 
-static int ex_prchars __P((SCR *,
-    const CHAR_T *, size_t *, size_t, u_int, int));
+static int ex_prchars(SCR *,
+    const CHAR_T *, size_t *, size_t, u_int, int);
 
 /*
  * ex_list -- :[line [,line]] l[ist] [count] [flags]
  *
  *	Display the addressed lines such that the output is unambiguous.
  *
- * PUBLIC: int ex_list __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_list(SCR *, EXCMD *);
  */
 int
 ex_list(SCR *sp, EXCMD *cmdp)
@@ -52,7 +52,7 @@ ex_list(SCR *sp, EXCMD *cmdp)
  *
  *	Display the addressed lines with a leading line number.
  *
- * PUBLIC: int ex_number __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_number(SCR *, EXCMD *);
  */
 int
 ex_number(SCR *sp, EXCMD *cmdp)
@@ -70,7 +70,7 @@ ex_number(SCR *sp, EXCMD *cmdp)
  *
  *	Display the addressed lines.
  *
- * PUBLIC: int ex_pr __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_pr(SCR *, EXCMD *);
  */
 int
 ex_pr(SCR *sp, EXCMD *cmdp)
@@ -86,7 +86,7 @@ ex_pr(SCR *sp, EXCMD *cmdp)
  * ex_print --
  *	Print the selected lines.
  *
- * PUBLIC: int ex_print __P((SCR *, EXCMD *, MARK *, MARK *, u_int32_t));
+ * PUBLIC: int ex_print(SCR *, EXCMD *, MARK *, MARK *, u_int32_t);
  */
 int
 ex_print(SCR *sp, EXCMD *cmdp, MARK *fp, MARK *tp, u_int32_t flags)
@@ -141,7 +141,7 @@ ex_print(SCR *sp, EXCMD *cmdp, MARK *fp, MARK *tp, u_int32_t flags)
  * ex_ldisplay --
  *	Display a line without any preceding number.
  *
- * PUBLIC: int ex_ldisplay __P((SCR *, const CHAR_T *, size_t, size_t, u_int));
+ * PUBLIC: int ex_ldisplay(SCR *, const CHAR_T *, size_t, size_t, u_int);
  */
 int
 ex_ldisplay(SCR *sp, const CHAR_T *p, size_t len, size_t col, u_int flags)
@@ -162,7 +162,7 @@ ex_ldisplay(SCR *sp, const CHAR_T *p, size_t len, size_t col, u_int flags)
  * ex_scprint --
  *	Display a line for the substitute with confirmation routine.
  *
- * PUBLIC: int ex_scprint __P((SCR *, MARK *, MARK *));
+ * PUBLIC: int ex_scprint(SCR *, MARK *, MARK *);
  */
 int
 ex_scprint(SCR *sp, MARK *fp, MARK *tp)
@@ -258,7 +258,7 @@ intr:	*colp = col;
  * ex_printf --
  *	Ex's version of printf.
  *
- * PUBLIC: int ex_printf __P((SCR *, const char *, ...));
+ * PUBLIC: int ex_printf(SCR *, const char *, ...);
  */
 int
 ex_printf(
@@ -288,7 +288,7 @@ ex_printf(
  * ex_puts --
  *	Ex's version of puts.
  *
- * PUBLIC: int ex_puts __P((SCR *, const char *));
+ * PUBLIC: int ex_puts(SCR *, const char *);
  */
 int
 ex_puts(SCR *sp, const char *str)
@@ -314,7 +314,7 @@ ex_puts(SCR *sp, const char *str)
  * ex_fflush --
  *	Ex's version of fflush.
  *
- * PUBLIC: int ex_fflush __P((SCR *sp));
+ * PUBLIC: int ex_fflush(SCR *sp);
  */
 int
 ex_fflush(SCR *sp)

--- a/ex/ex_put.c
+++ b/ex/ex_put.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: ex_put.c,v 10.8 2001/06/25 15:19:18 skimo Exp
  * ex_put -- [line] pu[t] [buffer]
  *	Append a cut buffer into the file.
  *
- * PUBLIC: int ex_put __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_put(SCR *, EXCMD *);
  */
 int
 ex_put(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_quit.c
+++ b/ex/ex_quit.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_quit.c,v 10.8 2001/06/25 15:19:18 skimo Ex
  * ex_quit -- :quit[!]
  *	Quit.
  *
- * PUBLIC: int ex_quit __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_quit(SCR *, EXCMD *);
  */
 int
 ex_quit(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_read.c
+++ b/ex/ex_read.c
@@ -36,7 +36,7 @@ static const char sccsid[] = "$Id: ex_read.c,v 10.44 2001/06/25 15:19:19 skimo E
  * !!!
  * Historical vi wouldn't undo a filter read, for no apparent reason.
  *
- * PUBLIC: int ex_read __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_read(SCR *, EXCMD *);
  */
 int
 ex_read(SCR *sp, EXCMD *cmdp)
@@ -291,7 +291,7 @@ ex_read(SCR *sp, EXCMD *cmdp)
  * ex_readfp --
  *	Read lines into the file.
  *
- * PUBLIC: int ex_readfp __P((SCR *, char *, FILE *, MARK *, recno_t *, int));
+ * PUBLIC: int ex_readfp(SCR *, char *, FILE *, MARK *, recno_t *, int);
  */
 int
 ex_readfp(SCR *sp, char *name, FILE *fp, MARK *fm, recno_t *nlinesp, int silent)

--- a/ex/ex_screen.c
+++ b/ex/ex_screen.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: ex_screen.c,v 10.12 2001/06/25 15:19:19 skimo
  * ex_bg --	:bg
  *	Hide the screen.
  *
- * PUBLIC: int ex_bg __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_bg(SCR *, EXCMD *);
  */
 int
 ex_bg(SCR *sp, EXCMD *cmdp)
@@ -42,7 +42,7 @@ ex_bg(SCR *sp, EXCMD *cmdp)
  * ex_fg --	:fg [file]
  *	Show the screen.
  *
- * PUBLIC: int ex_fg __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_fg(SCR *, EXCMD *);
  */
 int
 ex_fg(SCR *sp, EXCMD *cmdp)
@@ -66,7 +66,7 @@ ex_fg(SCR *sp, EXCMD *cmdp)
  * ex_resize --	:resize [+-]rows
  *	Change the screen size.
  *
- * PUBLIC: int ex_resize __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_resize(SCR *, EXCMD *);
  */
 int
 ex_resize(SCR *sp, EXCMD *cmdp)
@@ -95,7 +95,7 @@ ex_resize(SCR *sp, EXCMD *cmdp)
  * ex_sdisplay --
  *	Display the list of screens.
  *
- * PUBLIC: int ex_sdisplay __P((SCR *));
+ * PUBLIC: int ex_sdisplay(SCR *);
  */
 int
 ex_sdisplay(SCR *sp)

--- a/ex/ex_script.c
+++ b/ex/ex_script.c
@@ -45,18 +45,18 @@ static const char sccsid[] = "$Id: ex_script.c,v 10.44 2012/10/05 10:17:47 zy Ex
 #include "script.h"
 #include "pathnames.h"
 
-static void	sscr_check __P((SCR *));
-static int	sscr_getprompt __P((SCR *));
-static int	sscr_init __P((SCR *));
-static int	sscr_insert __P((SCR *));
-static int	sscr_matchprompt __P((SCR *, char *, size_t, size_t *));
-static int	sscr_setprompt __P((SCR *, char *, size_t));
+static void	sscr_check(SCR *);
+static int	sscr_getprompt(SCR *);
+static int	sscr_init(SCR *);
+static int	sscr_insert(SCR *);
+static int	sscr_matchprompt(SCR *, char *, size_t, size_t *);
+static int	sscr_setprompt(SCR *, char *, size_t);
 
 /*
  * ex_script -- : sc[ript][!] [file]
  *	Switch to script mode.
  *
- * PUBLIC: int ex_script __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_script(SCR *, EXCMD *);
  */
 int
 ex_script(SCR *sp, EXCMD *cmdp)
@@ -292,7 +292,7 @@ prompterr:	sscr_end(sp);
  * sscr_exec --
  *	Take a line and hand it off to the shell.
  *
- * PUBLIC: int sscr_exec __P((SCR *, recno_t));
+ * PUBLIC: int sscr_exec(SCR *, recno_t);
  */
 int
 sscr_exec(SCR *sp, recno_t lno)
@@ -368,7 +368,7 @@ err1:			rval = 1;
  * sscr_input --
  *	Read any waiting shell input.
  *
- * PUBLIC: int sscr_input __P((SCR *));
+ * PUBLIC: int sscr_input(SCR *);
  */
 int
 sscr_input(SCR *sp)
@@ -577,7 +577,7 @@ sscr_matchprompt(SCR *sp, char *lp, size_t line_len, size_t *lenp)
  * sscr_end --
  *	End the pipe to a shell.
  *
- * PUBLIC: int sscr_end __P((SCR *));
+ * PUBLIC: int sscr_end(SCR *);
  */
 int
 sscr_end(SCR *sp)

--- a/ex/ex_set.c
+++ b/ex/ex_set.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_set.c,v 10.8 2001/06/25 15:19:19 skimo Exp
  * ex_set -- :set
  *	Ex set option.
  *
- * PUBLIC: int ex_set __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_set(SCR *, EXCMD *);
  */
 int
 ex_set(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_shell.c
+++ b/ex/ex_shell.c
@@ -29,14 +29,14 @@ static const char sccsid[] = "$Id: ex_shell.c,v 10.44 2012/07/06 06:51:26 zy Exp
 
 #include "../common/common.h"
 
-static const char *sigmsg __P((int));
+static const char *sigmsg(int);
 
 /*
  * ex_shell -- :sh[ell]
  *	Invoke the program named in the SHELL environment variable
  *	with the argument -i.
  *
- * PUBLIC: int ex_shell __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_shell(SCR *, EXCMD *);
  */
 int
 ex_shell(SCR *sp, EXCMD *cmdp)
@@ -82,7 +82,7 @@ ex_shell(SCR *sp, EXCMD *cmdp)
  * ex_exec_proc --
  *	Run a separate process.
  *
- * PUBLIC: int ex_exec_proc __P((SCR *, EXCMD *, char *, const char *, int));
+ * PUBLIC: int ex_exec_proc(SCR *, EXCMD *, char *, const char *, int);
  */
 int
 ex_exec_proc(SCR *sp, EXCMD *cmdp, char *cmd, const char *msg, int need_newline)
@@ -147,7 +147,7 @@ ex_exec_proc(SCR *sp, EXCMD *cmdp, char *cmd, const char *msg, int need_newline)
  * rules get you.  I'm using a long based on the belief that nobody is
  * going to make it unsigned and it's unlikely to be a quad.
  *
- * PUBLIC: int proc_wait __P((SCR *, long, const char *, int, int));
+ * PUBLIC: int proc_wait(SCR *, long, const char *, int, int);
  */
 int
 proc_wait(SCR *sp, long int pid, const char *cmd, int silent, int okpipe)

--- a/ex/ex_shift.c
+++ b/ex/ex_shift.c
@@ -26,13 +26,13 @@ static const char sccsid[] = "$Id: ex_shift.c,v 10.17 2001/06/25 15:19:20 skimo 
 #include "../common/common.h"
 
 enum which {LEFT, RIGHT};
-static int shift __P((SCR *, EXCMD *, enum which));
+static int shift(SCR *, EXCMD *, enum which);
 
 /*
  * ex_shiftl -- :<[<...]
  *
  *
- * PUBLIC: int ex_shiftl __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_shiftl(SCR *, EXCMD *);
  */
 int
 ex_shiftl(SCR *sp, EXCMD *cmdp)
@@ -43,7 +43,7 @@ ex_shiftl(SCR *sp, EXCMD *cmdp)
 /*
  * ex_shiftr -- :>[>...]
  *
- * PUBLIC: int ex_shiftr __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_shiftr(SCR *, EXCMD *);
  */
 int
 ex_shiftr(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_source.c
+++ b/ex/ex_source.c
@@ -32,7 +32,7 @@ static const char sccsid[] = "$Id: ex_source.c,v 10.17 2011/12/19 16:17:06 zy Ex
  * ex_source -- :source file
  *	Execute ex commands from a file.
  *
- * PUBLIC: int ex_source __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_source(SCR *, EXCMD *);
  */
 int
 ex_source(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_stop.c
+++ b/ex/ex_stop.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_stop.c,v 10.11 2001/06/25 15:19:20 skimo E
  *	      :suspend[!]
  *	Suspend execution.
  *
- * PUBLIC: int ex_stop __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_stop(SCR *, EXCMD *);
  */
 int
 ex_stop(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -32,12 +32,12 @@ static const char sccsid[] = "$Id: ex_subst.c,v 10.53 2011/12/21 20:40:35 zy Exp
 #define	SUB_FIRST	0x01		/* The 'r' flag isn't reasonable. */
 #define	SUB_MUSTSETR	0x02		/* The 'r' flag is required. */
 
-static int re_conv __P((SCR *, CHAR_T **, size_t *, int *));
-static int re_cscope_conv __P((SCR *, CHAR_T **, size_t *, int *));
-static int re_sub __P((SCR *,
-		CHAR_T *, CHAR_T **, size_t *, size_t *, regmatch_t [10]));
-static int re_tag_conv __P((SCR *, CHAR_T **, size_t *, int *));
-static int s __P((SCR *, EXCMD *, CHAR_T *, regex_t *, u_int));
+static int re_conv(SCR *, CHAR_T **, size_t *, int *);
+static int re_cscope_conv(SCR *, CHAR_T **, size_t *, int *);
+static int re_sub(SCR *,
+		CHAR_T *, CHAR_T **, size_t *, size_t *, regmatch_t [10]);
+static int re_tag_conv(SCR *, CHAR_T **, size_t *, int *);
+static int s(SCR *, EXCMD *, CHAR_T *, regex_t *, u_int);
 
 /*
  * ex_s --
@@ -45,7 +45,7 @@ static int s __P((SCR *, EXCMD *, CHAR_T *, regex_t *, u_int));
  *
  *	Substitute on lines matching a pattern.
  *
- * PUBLIC: int ex_s __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_s(SCR *, EXCMD *);
  */
 int
 ex_s(SCR *sp, EXCMD *cmdp)
@@ -250,7 +250,7 @@ tilde:				++p;
  *
  *	Substitute using the last substitute RE and replacement pattern.
  *
- * PUBLIC: int ex_subagain __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_subagain(SCR *, EXCMD *);
  */
 int
 ex_subagain(SCR *sp, EXCMD *cmdp)
@@ -273,7 +273,7 @@ ex_subagain(SCR *sp, EXCMD *cmdp)
  *
  *	Substitute using the last RE and last substitute replacement pattern.
  *
- * PUBLIC: int ex_subtilde __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_subtilde(SCR *, EXCMD *);
  */
 int
 ex_subtilde(SCR *sp, EXCMD *cmdp)
@@ -879,8 +879,8 @@ err:		rval = 1;
  * re_compile --
  *	Compile the RE.
  *
- * PUBLIC: int re_compile __P((SCR *,
- * PUBLIC:     CHAR_T *, size_t, CHAR_T **, size_t *, regex_t *, u_int));
+ * PUBLIC: int re_compile(SCR *,
+ * PUBLIC:     CHAR_T *, size_t, CHAR_T **, size_t *, regex_t *, u_int);
  */
 int
 re_compile(SCR *sp, CHAR_T *ptrn, size_t plen, CHAR_T **ptrnp, size_t *lenp, regex_t *rep, u_int flags)
@@ -1280,7 +1280,7 @@ re_cscope_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
  * re_error --
  *	Report a regular expression error.
  *
- * PUBLIC: void re_error __P((SCR *, int, regex_t *));
+ * PUBLIC: void re_error(SCR *, int, regex_t *);
  */
 void
 re_error(SCR *sp, int errcode, regex_t *preg)

--- a/ex/ex_tag.c
+++ b/ex/ex_tag.c
@@ -36,24 +36,24 @@ static const char sccsid[] = "$Id: ex_tag.c,v 10.54 2012/04/12 07:17:30 zy Exp $
 #include "../vi/vi.h"
 #include "tag.h"
 
-static char	*binary_search __P((char *, char *, char *));
-static int	 compare __P((char *, char *, char *));
-static void	 ctag_file __P((SCR *, TAGF *, char *, char **, size_t *));
-static int	 ctag_search __P((SCR *, CHAR_T *, size_t, char *));
-static int	 ctag_sfile __P((SCR *, TAGF *, TAGQ *, char *));
-static TAGQ	*ctag_slist __P((SCR *, CHAR_T *));
-static char	*linear_search __P((char *, char *, char *, long));
-static int	 tag_copy __P((SCR *, TAG *, TAG **));
-static int	 tag_pop __P((SCR *, TAGQ *, int));
-static int	 tagf_copy __P((SCR *, TAGF *, TAGF **));
-static int	 tagf_free __P((SCR *, TAGF *));
-static int	 tagq_copy __P((SCR *, TAGQ *, TAGQ **));
+static char	*binary_search(char *, char *, char *);
+static int	 compare(char *, char *, char *);
+static void	 ctag_file(SCR *, TAGF *, char *, char **, size_t *);
+static int	 ctag_search(SCR *, CHAR_T *, size_t, char *);
+static int	 ctag_sfile(SCR *, TAGF *, TAGQ *, char *);
+static TAGQ	*ctag_slist(SCR *, CHAR_T *);
+static char	*linear_search(char *, char *, char *, long);
+static int	 tag_copy(SCR *, TAG *, TAG **);
+static int	 tag_pop(SCR *, TAGQ *, int);
+static int	 tagf_copy(SCR *, TAGF *, TAGF **);
+static int	 tagf_free(SCR *, TAGF *);
+static int	 tagq_copy(SCR *, TAGQ *, TAGQ **);
 
 /*
  * ex_tag_first --
  *	The tag code can be entered from main, e.g., "vi -t tag".
  *
- * PUBLIC: int ex_tag_first __P((SCR *, CHAR_T *));
+ * PUBLIC: int ex_tag_first(SCR *, CHAR_T *);
  */
 int
 ex_tag_first(SCR *sp, CHAR_T *tagarg)
@@ -86,7 +86,7 @@ ex_tag_first(SCR *sp, CHAR_T *tagarg)
  *
  * Enter a new TAGQ context based on a ctag string.
  *
- * PUBLIC: int ex_tag_push __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_tag_push(SCR *, EXCMD *);
  */
 int
 ex_tag_push(SCR *sp, EXCMD *cmdp)
@@ -137,7 +137,7 @@ ex_tag_push(SCR *sp, EXCMD *cmdp)
  * ex_tag_next --
  *	Switch context to the next TAG.
  *
- * PUBLIC: int ex_tag_next __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_tag_next(SCR *, EXCMD *);
  */
 int
 ex_tag_next(SCR *sp, EXCMD *cmdp)
@@ -177,7 +177,7 @@ ex_tag_next(SCR *sp, EXCMD *cmdp)
  * ex_tag_prev --
  *	Switch context to the next TAG.
  *
- * PUBLIC: int ex_tag_prev __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_tag_prev(SCR *, EXCMD *);
  */
 int
 ex_tag_prev(SCR *sp, EXCMD *cmdp)
@@ -217,7 +217,7 @@ ex_tag_prev(SCR *sp, EXCMD *cmdp)
  * ex_tag_nswitch --
  *	Switch context to the specified TAG.
  *
- * PUBLIC: int ex_tag_nswitch __P((SCR *, TAG *, int));
+ * PUBLIC: int ex_tag_nswitch(SCR *, TAG *, int);
  */
 int
 ex_tag_nswitch(SCR *sp, TAG *tp, int force)
@@ -251,7 +251,7 @@ ex_tag_nswitch(SCR *sp, TAG *tp, int force)
  * ex_tag_Nswitch --
  *	Switch context to the specified TAG in a new screen.
  *
- * PUBLIC: int ex_tag_Nswitch __P((SCR *, TAG *, int));
+ * PUBLIC: int ex_tag_Nswitch(SCR *, TAG *, int);
  */
 int
 ex_tag_Nswitch(SCR *sp, TAG *tp, int force)
@@ -305,7 +305,7 @@ ex_tag_Nswitch(SCR *sp, TAG *tp, int force)
  *
  *	Pop to a previous TAGQ context.
  *
- * PUBLIC: int ex_tag_pop __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_tag_pop(SCR *, EXCMD *);
  */
 int
 ex_tag_pop(SCR *sp, EXCMD *cmdp)
@@ -384,7 +384,7 @@ filearg:	arglen = strlen(arg);
  * ex_tag_top -- :tagt[op][!]
  *	Clear the tag stack.
  *
- * PUBLIC: int ex_tag_top __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_tag_top(SCR *, EXCMD *);
  */
 int
 ex_tag_top(SCR *sp, EXCMD *cmdp)
@@ -459,7 +459,7 @@ tag_pop(SCR *sp, TAGQ *dtqp, int force)
  * ex_tag_display --
  *	Display the list of tags.
  *
- * PUBLIC: int ex_tag_display __P((SCR *));
+ * PUBLIC: int ex_tag_display(SCR *);
  */
 int
 ex_tag_display(SCR *sp)
@@ -536,7 +536,7 @@ ex_tag_display(SCR *sp)
  * ex_tag_copy --
  *	Copy a screen's tag structures.
  *
- * PUBLIC: int ex_tag_copy __P((SCR *, SCR *));
+ * PUBLIC: int ex_tag_copy(SCR *, SCR *);
  */
 int
 ex_tag_copy(SCR *orig, SCR *sp)
@@ -677,7 +677,7 @@ tagf_free(SCR *sp, TAGF *tfp)
  * tagq_free --
  *	Free a TAGQ structure (and associated TAG structures).
  *
- * PUBLIC: int tagq_free __P((SCR *, TAGQ *));
+ * PUBLIC: int tagq_free(SCR *, TAGQ *);
  */
 int
 tagq_free(SCR *sp, TAGQ *tqp)
@@ -702,7 +702,7 @@ tagq_free(SCR *sp, TAGQ *tqp)
 }
 
 /*
- * PUBLIC: int tagq_push __P((SCR*, TAGQ*, int, int ));
+ * PUBLIC: int tagq_push(SCR*, TAGQ*, int, int );
  */
 int
 tagq_push(SCR *sp, TAGQ *tqp, int new_screen, int force)
@@ -814,7 +814,7 @@ alloc_err:
  * tag_msg
  *	A few common messages.
  *
- * PUBLIC: void tag_msg __P((SCR *, tagmsg_t, char *));
+ * PUBLIC: void tag_msg(SCR *, tagmsg_t, char *);
  */
 void
 tag_msg(SCR *sp, tagmsg_t msg, char *tag)
@@ -839,7 +839,7 @@ tag_msg(SCR *sp, tagmsg_t msg, char *tag)
  * ex_tagf_alloc --
  *	Create a new list of ctag files.
  *
- * PUBLIC: int ex_tagf_alloc __P((SCR *, char *));
+ * PUBLIC: int ex_tagf_alloc(SCR *, char *);
  */
 int
 ex_tagf_alloc(SCR *sp, char *str)
@@ -881,7 +881,7 @@ ex_tagf_alloc(SCR *sp, char *str)
  * ex_tag_free --
  *	Free the ex tag information.
  *
- * PUBLIC: int ex_tag_free __P((SCR *));
+ * PUBLIC: int ex_tag_free(SCR *);
  */
 int
 ex_tag_free(SCR *sp)

--- a/ex/ex_txt.c
+++ b/ex/ex_txt.c
@@ -44,14 +44,14 @@ static const char sccsid[] = "$Id: ex_txt.c,v 10.23 2001/06/25 15:19:21 skimo Ex
  * characters remaining when failure occurred.
  */
 
-static int	txt_dent __P((SCR *, TEXT *));
-static void	txt_prompt __P((SCR *, TEXT *, ARG_CHAR_T, u_int32_t));
+static int	txt_dent(SCR *, TEXT *);
+static void	txt_prompt(SCR *, TEXT *, ARG_CHAR_T, u_int32_t);
 
 /*
  * ex_txt --
  *	Get lines from the terminal for ex.
  *
- * PUBLIC: int ex_txt __P((SCR *, TEXTH *, ARG_CHAR_T, u_int32_t));
+ * PUBLIC: int ex_txt(SCR *, TEXTH *, ARG_CHAR_T, u_int32_t);
  */
 int
 ex_txt(SCR *sp, TEXTH *tiqh, ARG_CHAR_T prompt, u_int32_t flags)

--- a/ex/ex_undo.c
+++ b/ex/ex_undo.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: ex_undo.c,v 10.7 2001/06/25 15:19:21 skimo Ex
  * ex_undo -- u
  *	Undo the last change.
  *
- * PUBLIC: int ex_undo __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_undo(SCR *, EXCMD *);
  */
 int
 ex_undo(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_usage.c
+++ b/ex/ex_usage.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_usage.c,v 10.16 2011/12/21 19:26:48 zy Exp
  * ex_help -- :help
  *	Display help message.
  *
- * PUBLIC: int ex_help __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_help(SCR *, EXCMD *);
  */
 int
 ex_help(SCR *sp, EXCMD *cmdp)
@@ -52,7 +52,7 @@ ex_help(SCR *sp, EXCMD *cmdp)
  * ex_usage -- :exusage [cmd]
  *	Display ex usage strings.
  *
- * PUBLIC: int ex_usage __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_usage(SCR *, EXCMD *);
  */
 int
 ex_usage(SCR *sp, EXCMD *cmdp)
@@ -133,7 +133,7 @@ ex_usage(SCR *sp, EXCMD *cmdp)
  * ex_viusage -- :viusage [key]
  *	Display vi usage strings.
  *
- * PUBLIC: int ex_viusage __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_viusage(SCR *, EXCMD *);
  */
 int
 ex_viusage(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_util.c
+++ b/ex/ex_util.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_util.c,v 10.32 2001/06/25 15:19:21 skimo E
  * ex_cinit --
  *	Create an EX command structure.
  *
- * PUBLIC: void ex_cinit __P((SCR *, EXCMD *, int, int, recno_t, recno_t, int));
+ * PUBLIC: void ex_cinit(SCR *, EXCMD *, int, int, recno_t, recno_t, int);
  */
 void
 ex_cinit(SCR *sp, EXCMD *cmdp, int cmd_id, int naddr, recno_t lno1, recno_t lno2, int force)
@@ -51,7 +51,7 @@ ex_cinit(SCR *sp, EXCMD *cmdp, int cmd_id, int naddr, recno_t lno1, recno_t lno2
  * ex_getline --
  *	Return a line from the file.
  *
- * PUBLIC: int ex_getline __P((SCR *, FILE *, size_t *));
+ * PUBLIC: int ex_getline(SCR *, FILE *, size_t *);
  */
 int
 ex_getline(SCR *sp, FILE *fp, size_t *lenp)
@@ -91,7 +91,7 @@ ex_getline(SCR *sp, FILE *fp, size_t *lenp)
  * ex_ncheck --
  *	Check for more files to edit.
  *
- * PUBLIC: int ex_ncheck __P((SCR *, int));
+ * PUBLIC: int ex_ncheck(SCR *, int);
  */
 int
 ex_ncheck(SCR *sp, int force)
@@ -120,7 +120,7 @@ ex_ncheck(SCR *sp, int force)
  * ex_init --
  *	Init the screen for ex.
  *
- * PUBLIC: int ex_init __P((SCR *));
+ * PUBLIC: int ex_init(SCR *);
  */
 int
 ex_init(SCR *sp)
@@ -145,7 +145,7 @@ ex_init(SCR *sp)
  * ex_emsg --
  *	Display a few common ex and vi error messages.
  *
- * PUBLIC: void ex_wemsg __P((SCR *, CHAR_T *, exm_t));
+ * PUBLIC: void ex_wemsg(SCR *, CHAR_T *, exm_t);
  */
 void
 ex_wemsg(SCR* sp, CHAR_T *p, exm_t which)
@@ -162,7 +162,7 @@ ex_wemsg(SCR* sp, CHAR_T *p, exm_t which)
  * ex_emsg --
  *	Display a few common ex and vi error messages.
  *
- * PUBLIC: void ex_emsg __P((SCR *, char *, exm_t));
+ * PUBLIC: void ex_emsg(SCR *, char *, exm_t);
  */
 void
 ex_emsg(SCR *sp, char *p, exm_t which)

--- a/ex/ex_version.c
+++ b/ex/ex_version.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: ex_version.c,v 10.32 2001/06/25 15:19:22 skim
  * ex_version -- :version
  *	Display the program version.
  *
- * PUBLIC: int ex_version __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_version(SCR *, EXCMD *);
  */
 int
 ex_version(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_visual.c
+++ b/ex/ex_visual.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: ex_visual.c,v 10.16 2001/08/29 11:04:13 skimo
  * ex_visual -- :[line] vi[sual] [^-.+] [window_size] [flags]
  *	Switch to visual mode.
  *
- * PUBLIC: int ex_visual __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_visual(SCR *, EXCMD *);
  */
 int
 ex_visual(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_write.c
+++ b/ex/ex_write.c
@@ -30,13 +30,13 @@ static const char sccsid[] = "$Id: ex_write.c,v 10.42 2014/03/05 16:07:04 zy Exp
 #include "../common/common.h"
 
 enum which {WN, WQ, WRITE, XIT};
-static int exwr __P((SCR *, EXCMD *, enum which));
+static int exwr(SCR *, EXCMD *, enum which);
 
 /*
  * ex_wn --	:wn[!] [>>] [file]
  *	Write to a file and switch to the next one.
  *
- * PUBLIC: int ex_wn __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_wn(SCR *, EXCMD *);
  */
 int
 ex_wn(SCR *sp, EXCMD *cmdp)
@@ -56,7 +56,7 @@ ex_wn(SCR *sp, EXCMD *cmdp)
  * ex_wq --	:wq[!] [>>] [file]
  *	Write to a file and quit.
  *
- * PUBLIC: int ex_wq __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_wq(SCR *, EXCMD *);
  */
 int
 ex_wq(SCR *sp, EXCMD *cmdp)
@@ -82,7 +82,7 @@ ex_wq(SCR *sp, EXCMD *cmdp)
  *		:write [!] [cmd]
  *	Write to a file.
  *
- * PUBLIC: int ex_write __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_write(SCR *, EXCMD *);
  */
 int
 ex_write(SCR *sp, EXCMD *cmdp)
@@ -95,7 +95,7 @@ ex_write(SCR *sp, EXCMD *cmdp)
  * ex_xit -- :x[it]! [file]
  *	Write out any modifications and quit.
  *
- * PUBLIC: int ex_xit __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_xit(SCR *, EXCMD *);
  */
 int
 ex_xit(SCR *sp, EXCMD *cmdp)
@@ -278,8 +278,8 @@ exwr(SCR *sp, EXCMD *cmdp, enum which cmd)
  * ex_writefp --
  *	Write a range of lines to a FILE *.
  *
- * PUBLIC: int ex_writefp __P((SCR *,
- * PUBLIC:    char *, FILE *, MARK *, MARK *, u_long *, u_long *, int));
+ * PUBLIC: int ex_writefp(SCR *,
+ * PUBLIC:    char *, FILE *, MARK *, MARK *, u_long *, u_long *, int);
  */
 int
 ex_writefp(SCR *sp, char *name, FILE *fp, MARK *fm, MARK *tm, u_long *nlno, u_long *nch, int silent)

--- a/ex/ex_yank.c
+++ b/ex/ex_yank.c
@@ -27,7 +27,7 @@ static const char sccsid[] = "$Id: ex_yank.c,v 10.8 2001/06/25 15:19:22 skimo Ex
  * ex_yank -- :[line [,line]] ya[nk] [buffer] [count]
  *	Yank the lines into a buffer.
  *
- * PUBLIC: int ex_yank __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_yank(SCR *, EXCMD *);
  */
 int
 ex_yank(SCR *sp, EXCMD *cmdp)

--- a/ex/ex_z.c
+++ b/ex/ex_z.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: ex_z.c,v 10.12 2001/06/25 15:19:22 skimo Exp 
  * ex_z -- :[line] z [^-.+=] [count] [flags]
  *	Adjust window.
  *
- * PUBLIC: int ex_z __P((SCR *, EXCMD *));
+ * PUBLIC: int ex_z(SCR *, EXCMD *);
  */
 int
 ex_z(SCR *sp, EXCMD *cmdp)

--- a/regex/engine.c
+++ b/regex/engine.c
@@ -88,12 +88,12 @@ extern "C" {
 #endif
 
 /* === engine.c === */
-static int matcher __P((struct re_guts *g, const RCHAR_T *string, size_t nmatch, regmatch_t pmatch[], int eflags));
-static const RCHAR_T *dissect __P((struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst));
-static const RCHAR_T *backref __P((struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst, sopno lev));
-static const RCHAR_T *fast __P((struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst));
-static const RCHAR_T *slow __P((struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst));
-static states step __P((struct re_guts *g, sopno start, sopno stop, states bef, int flag, RCHAR_T ch, states aft));
+static int matcher(struct re_guts *g, const RCHAR_T *string, size_t nmatch, regmatch_t pmatch[], int eflags);
+static const RCHAR_T *dissect(struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst);
+static const RCHAR_T *backref(struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst, sopno lev);
+static const RCHAR_T *fast(struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst);
+static const RCHAR_T *slow(struct match *m, const RCHAR_T *start, const RCHAR_T *stop, sopno startst, sopno stopst);
+static states step(struct re_guts *g, sopno start, sopno stop, states bef, int flag, RCHAR_T ch, states aft);
 #define	BOL	(1)
 #define	EOL	(BOL+1)
 #define	BOLEOL	(BOL+2)
@@ -101,13 +101,13 @@ static states step __P((struct re_guts *g, sopno start, sopno stop, states bef, 
 #define	BOW	(BOL+4)
 #define	EOW	(BOL+5)
 #ifdef REDEBUG
-static void print __P((struct match *m, char *caption, states st, int ch, FILE *d));
+static void print(struct match *m, char *caption, states st, int ch, FILE *d);
 #endif
 #ifdef REDEBUG
-static void at __P((struct match *m, char *title, char *start, char *stop, sopno startst, sopno stopst));
+static void at(struct match *m, char *title, char *start, char *stop, sopno startst, sopno stopst);
 #endif
 #ifdef REDEBUG
-static char *pchar __P((int ch));
+static char *pchar(int ch);
 #endif
 
 #ifdef __cplusplus

--- a/regex/regcomp.c
+++ b/regex/regcomp.c
@@ -78,50 +78,50 @@ extern "C" {
 #endif
 
 /* === regcomp.c === */
-static void p_ere __P((struct parse *p, int stop, size_t reclimit));
-static void p_ere_exp __P((struct parse *p, size_t reclimit));
-static void p_str __P((struct parse *p));
-static void p_bre __P((struct parse *p, int end1, int end2, size_t reclimit));
-static int p_simp_re __P((struct parse *p, int starordinary, size_t reclimit));
-static int p_count __P((struct parse *p));
-static void p_bracket __P((struct parse *p));
-static void p_b_term __P((struct parse *p, cset *cs));
-static void p_b_cclass __P((struct parse *p, cset *cs));
-static void p_b_eclass __P((struct parse *p, cset *cs));
-static char p_b_symbol __P((struct parse *p));
-static char p_b_coll_elem __P((struct parse *p, int endc));
-static char othercase __P((int ch));
-static void bothcases __P((struct parse *p, int ch));
-static void ordinary __P((struct parse *p, int ch));
-static void nonnewline __P((struct parse *p));
-static void repeat __P((struct parse *p, sopno start, int from, int to, size_t reclimit));
-static int seterr __P((struct parse *p, int e));
-static cset *allocset __P((struct parse *p));
-static void freeset __P((struct parse *p, cset *cs));
-static int freezeset __P((struct parse *p, cset *cs));
-static int firstch __P((struct parse *p, cset *cs));
-static int nch __P((struct parse *p, cset *cs));
-static void mcadd __P((struct parse *p, cset *cs, const char *cp));
+static void p_ere(struct parse *p, int stop, size_t reclimit);
+static void p_ere_exp(struct parse *p, size_t reclimit);
+static void p_str(struct parse *p);
+static void p_bre(struct parse *p, int end1, int end2, size_t reclimit);
+static int p_simp_re(struct parse *p, int starordinary, size_t reclimit);
+static int p_count(struct parse *p);
+static void p_bracket(struct parse *p);
+static void p_b_term(struct parse *p, cset *cs);
+static void p_b_cclass(struct parse *p, cset *cs);
+static void p_b_eclass(struct parse *p, cset *cs);
+static char p_b_symbol(struct parse *p);
+static char p_b_coll_elem(struct parse *p, int endc);
+static char othercase(int ch);
+static void bothcases(struct parse *p, int ch);
+static void ordinary(struct parse *p, int ch);
+static void nonnewline(struct parse *p);
+static void repeat(struct parse *p, sopno start, int from, int to, size_t reclimit);
+static int seterr(struct parse *p, int e);
+static cset *allocset(struct parse *p);
+static void freeset(struct parse *p, cset *cs);
+static int freezeset(struct parse *p, cset *cs);
+static int firstch(struct parse *p, cset *cs);
+static int nch(struct parse *p, cset *cs);
+static void mcadd(struct parse *p, cset *cs, const char *cp);
 #ifdef notdef
-static void mcsub __P((cset *cs, char *cp));
-static int mcin __P((cset *cs, char *cp));
-static char *mcfind __P((cset *cs, char *cp));
+static void mcsub(cset *cs, char *cp);
+static int mcin(cset *cs, char *cp);
+static char *mcfind(cset *cs, char *cp);
 #endif
-static void mcinvert __P((struct parse *p, cset *cs));
-static void mccase __P((struct parse *p, cset *cs));
+static void mcinvert(struct parse *p, cset *cs);
+static void mccase(struct parse *p, cset *cs);
 #ifdef notdef
-static int isinsets __P((struct re_guts *g, int c));
-static int samesets __P((struct re_guts *g, int c1, int c2));
+static int isinsets(struct re_guts *g, int c);
+static int samesets(struct re_guts *g, int c1, int c2);
 #endif
-static void categorize __P((struct parse *p, struct re_guts *g));
-static sopno dupl __P((struct parse *p, sopno start, sopno finish));
-static void doemit __P((struct parse *p, sop op, size_t opnd));
-static void doinsert __P((struct parse *p, sop op, size_t opnd, sopno pos));
-static void dofwd __P((struct parse *p, sopno pos, sop value));
-static int enlarge __P((struct parse *p, sopno size));
-static void stripsnug __P((struct parse *p, struct re_guts *g));
-static void findmust __P((struct parse *p, struct re_guts *g));
-static sopno pluscount __P((struct parse *p, struct re_guts *g));
+static void categorize(struct parse *p, struct re_guts *g);
+static sopno dupl(struct parse *p, sopno start, sopno finish);
+static void doemit(struct parse *p, sop op, size_t opnd);
+static void doinsert(struct parse *p, sop op, size_t opnd, sopno pos);
+static void dofwd(struct parse *p, sopno pos, sop value);
+static int enlarge(struct parse *p, sopno size);
+static void stripsnug(struct parse *p, struct re_guts *g);
+static void findmust(struct parse *p, struct re_guts *g);
+static sopno pluscount(struct parse *p, struct re_guts *g);
 
 #ifdef __cplusplus
 }

--- a/regex/regerror.c
+++ b/regex/regerror.c
@@ -55,7 +55,7 @@ extern "C" {
 #endif
 
 /* === regerror.c === */
-static char *regatoi __P((const regex_t *preg, char *localbuf));
+static char *regatoi(const regex_t *preg, char *localbuf);
 
 #ifdef __cplusplus
 }

--- a/regex/regex.h
+++ b/regex/regex.h
@@ -96,10 +96,10 @@ typedef struct {
 #define	REG_LARGE	01000	/* force large representation */
 #define	REG_BACKR	02000	/* force use of backref code */
 
-int	regcomp __P((regex_t *, const RCHAR_T *, int));
-size_t	regerror __P((int, const regex_t *, char *, size_t));
-int	regexec __P((const regex_t *,
-	    const RCHAR_T *, size_t, regmatch_t [], int));
-void	regfree __P((regex_t *));
+int	regcomp(regex_t *, const RCHAR_T *, int);
+size_t	regerror(int, const regex_t *, char *, size_t);
+int	regexec(const regex_t *,
+	    const RCHAR_T *, size_t, regmatch_t [], int);
+void	regfree(regex_t *);
 
 #endif /* !_REGEX_H_ */

--- a/vi/getc.c
+++ b/vi/getc.c
@@ -40,7 +40,7 @@ static const char sccsid[] = "$Id: getc.c,v 10.13 2011/12/27 00:49:31 zy Exp $";
  * cs_init --
  *	Initialize character stream routines.
  *
- * PUBLIC: int cs_init __P((SCR *, VCS *));
+ * PUBLIC: int cs_init(SCR *, VCS *);
  */
 int
 cs_init(SCR *sp, VCS *csp)
@@ -66,7 +66,7 @@ cs_init(SCR *sp, VCS *csp)
  * cs_next --
  *	Retrieve the next character.
  *
- * PUBLIC: int cs_next __P((SCR *, VCS *));
+ * PUBLIC: int cs_next(SCR *, VCS *);
  */
 int
 cs_next(SCR *sp, VCS *csp)
@@ -116,7 +116,7 @@ cs_next(SCR *sp, VCS *csp)
  * function -- once the other word routines are converted, they may have
  * to change.
  *
- * PUBLIC: int cs_fspace __P((SCR *, VCS *));
+ * PUBLIC: int cs_fspace(SCR *, VCS *);
  */
 int
 cs_fspace(SCR *sp, VCS *csp)
@@ -136,7 +136,7 @@ cs_fspace(SCR *sp, VCS *csp)
  * cs_fblank --
  *	Eat forward to the next non-whitespace character.
  *
- * PUBLIC: int cs_fblank __P((SCR *, VCS *));
+ * PUBLIC: int cs_fblank(SCR *, VCS *);
  */
 int
 cs_fblank(SCR *sp, VCS *csp)
@@ -156,7 +156,7 @@ cs_fblank(SCR *sp, VCS *csp)
  * cs_prev --
  *	Retrieve the previous character.
  *
- * PUBLIC: int cs_prev __P((SCR *, VCS *));
+ * PUBLIC: int cs_prev(SCR *, VCS *);
  */
 int
 cs_prev(SCR *sp, VCS *csp)
@@ -205,7 +205,7 @@ cs_prev(SCR *sp, VCS *csp)
  * cs_bblank --
  *	Eat backward to the next non-whitespace character.
  *
- * PUBLIC: int cs_bblank __P((SCR *, VCS *));
+ * PUBLIC: int cs_bblank(SCR *, VCS *);
  */
 int
 cs_bblank(SCR *sp, VCS *csp)

--- a/vi/v_at.c
+++ b/vi/v_at.c
@@ -30,7 +30,7 @@ static const char sccsid[] = "$Id: v_at.c,v 10.11 2001/06/25 15:19:30 skimo Exp 
  * v_at -- @
  *	Execute a buffer.
  *
- * PUBLIC: int v_at __P((SCR *, VICMD *));
+ * PUBLIC: int v_at(SCR *, VICMD *);
  */
 int
 v_at(SCR *sp, VICMD *vp)

--- a/vi/v_ch.c
+++ b/vi/v_ch.c
@@ -25,14 +25,14 @@ static const char sccsid[] = "$Id: v_ch.c,v 10.11 2011/12/02 19:49:50 zy Exp $";
 #include "../common/common.h"
 #include "vi.h"
 
-static void notfound __P((SCR *, ARG_CHAR_T));
-static void noprev __P((SCR *));
+static void notfound(SCR *, ARG_CHAR_T);
+static void noprev(SCR *);
 
 /*
  * v_chrepeat -- [count];
  *	Repeat the last F, f, T or t search.
  *
- * PUBLIC: int v_chrepeat __P((SCR *, VICMD *));
+ * PUBLIC: int v_chrepeat(SCR *, VICMD *);
  */
 int
 v_chrepeat(SCR *sp, VICMD *vp)
@@ -61,7 +61,7 @@ v_chrepeat(SCR *sp, VICMD *vp)
  * v_chrrepeat -- [count],
  *	Repeat the last F, f, T or t search in the reverse direction.
  *
- * PUBLIC: int v_chrrepeat __P((SCR *, VICMD *));
+ * PUBLIC: int v_chrrepeat(SCR *, VICMD *);
  */
 int
 v_chrrepeat(SCR *sp, VICMD *vp)
@@ -100,7 +100,7 @@ v_chrrepeat(SCR *sp, VICMD *vp)
  *	Search forward in the line for the character before the next
  *	occurrence of the specified character.
  *
- * PUBLIC: int v_cht __P((SCR *, VICMD *));
+ * PUBLIC: int v_cht(SCR *, VICMD *);
  */
 int
 v_cht(SCR *sp, VICMD *vp)
@@ -131,7 +131,7 @@ v_cht(SCR *sp, VICMD *vp)
  *	Search forward in the line for the next occurrence of the
  *	specified character.
  *
- * PUBLIC: int v_chf __P((SCR *, VICMD *));
+ * PUBLIC: int v_chf(SCR *, VICMD *);
  */
 int
 v_chf(SCR *sp, VICMD *vp)
@@ -188,7 +188,7 @@ empty:		notfound(sp, key);
  *	Search backward in the line for the character after the next
  *	occurrence of the specified character.
  *
- * PUBLIC: int v_chT __P((SCR *, VICMD *));
+ * PUBLIC: int v_chT(SCR *, VICMD *);
  */
 int
 v_chT(SCR *sp, VICMD *vp)
@@ -213,7 +213,7 @@ v_chT(SCR *sp, VICMD *vp)
  *	Search backward in the line for the next occurrence of the
  *	specified character.
  *
- * PUBLIC: int v_chF __P((SCR *, VICMD *));
+ * PUBLIC: int v_chF(SCR *, VICMD *);
  */
 int
 v_chF(SCR *sp, VICMD *vp)

--- a/vi/v_delete.c
+++ b/vi/v_delete.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: v_delete.c,v 10.11 2001/06/25 15:19:31 skimo 
  *	       [buffer][count]D
  *	Delete a range of text.
  *
- * PUBLIC: int v_delete __P((SCR *, VICMD *));
+ * PUBLIC: int v_delete(SCR *, VICMD *);
  */
 int
 v_delete(SCR *sp, VICMD *vp)

--- a/vi/v_ex.c
+++ b/vi/v_ex.c
@@ -27,17 +27,17 @@ static const char sccsid[] = "$Id: v_ex.c,v 10.61 2011/12/22 18:41:53 zy Exp $";
 #include "../common/common.h"
 #include "vi.h"
 
-static int v_ecl __P((SCR *));
-static int v_ecl_init __P((SCR *));
-static int v_ecl_log __P((SCR *, TEXT *));
-static int v_ex_done __P((SCR *, VICMD *));
-static int v_exec_ex __P((SCR *, VICMD *, EXCMD *));
+static int v_ecl(SCR *);
+static int v_ecl_init(SCR *);
+static int v_ecl_log(SCR *, TEXT *);
+static int v_ex_done(SCR *, VICMD *);
+static int v_exec_ex(SCR *, VICMD *, EXCMD *);
 
 /*
  * v_again -- &
  *	Repeat the previous substitution.
  *
- * PUBLIC: int v_again __P((SCR *, VICMD *));
+ * PUBLIC: int v_again(SCR *, VICMD *);
  */
 int
 v_again(SCR *sp, VICMD *vp)
@@ -53,7 +53,7 @@ v_again(SCR *sp, VICMD *vp)
  * v_exmode -- Q
  *	Switch the editor into EX mode.
  *
- * PUBLIC: int v_exmode __P((SCR *, VICMD *));
+ * PUBLIC: int v_exmode(SCR *, VICMD *);
  */
 int
 v_exmode(SCR *sp, VICMD *vp)
@@ -89,7 +89,7 @@ v_exmode(SCR *sp, VICMD *vp)
  * v_join -- [count]J
  *	Join lines together.
  *
- * PUBLIC: int v_join __P((SCR *, VICMD *));
+ * PUBLIC: int v_join(SCR *, VICMD *);
  */
 int
 v_join(SCR *sp, VICMD *vp)
@@ -118,7 +118,7 @@ v_join(SCR *sp, VICMD *vp)
  * v_shiftl -- [count]<motion
  *	Shift lines left.
  *
- * PUBLIC: int v_shiftl __P((SCR *, VICMD *));
+ * PUBLIC: int v_shiftl(SCR *, VICMD *);
  */
 int
 v_shiftl(SCR *sp, VICMD *vp)
@@ -134,7 +134,7 @@ v_shiftl(SCR *sp, VICMD *vp)
  * v_shiftr -- [count]>motion
  *	Shift lines right.
  *
- * PUBLIC: int v_shiftr __P((SCR *, VICMD *));
+ * PUBLIC: int v_shiftr(SCR *, VICMD *);
  */
 int
 v_shiftr(SCR *sp, VICMD *vp)
@@ -150,7 +150,7 @@ v_shiftr(SCR *sp, VICMD *vp)
  * v_suspend -- ^Z
  *	Suspend vi.
  *
- * PUBLIC: int v_suspend __P((SCR *, VICMD *));
+ * PUBLIC: int v_suspend(SCR *, VICMD *);
  */
 int
 v_suspend(SCR *sp, VICMD *vp)
@@ -166,7 +166,7 @@ v_suspend(SCR *sp, VICMD *vp)
  * v_switch -- ^^
  *	Switch to the previous file.
  *
- * PUBLIC: int v_switch __P((SCR *, VICMD *));
+ * PUBLIC: int v_switch(SCR *, VICMD *);
  */
 int
 v_switch(SCR *sp, VICMD *vp)
@@ -199,7 +199,7 @@ v_switch(SCR *sp, VICMD *vp)
  * v_tagpush -- ^[
  *	Do a tag search on the cursor keyword.
  *
- * PUBLIC: int v_tagpush __P((SCR *, VICMD *));
+ * PUBLIC: int v_tagpush(SCR *, VICMD *);
  */
 int
 v_tagpush(SCR *sp, VICMD *vp)
@@ -215,7 +215,7 @@ v_tagpush(SCR *sp, VICMD *vp)
  * v_tagpop -- ^T
  *	Pop the tags stack.
  *
- * PUBLIC: int v_tagpop __P((SCR *, VICMD *));
+ * PUBLIC: int v_tagpop(SCR *, VICMD *);
  */
 int
 v_tagpop(SCR *sp, VICMD *vp)
@@ -230,7 +230,7 @@ v_tagpop(SCR *sp, VICMD *vp)
  * v_filter -- [count]!motion command(s)
  *	Run range through shell commands, replacing text.
  *
- * PUBLIC: int v_filter __P((SCR *, VICMD *));
+ * PUBLIC: int v_filter(SCR *, VICMD *);
  */
 int
 v_filter(SCR *sp, VICMD *vp)
@@ -319,7 +319,7 @@ v_exec_ex(SCR *sp, VICMD *vp, EXCMD *exp)
  * v_ex -- :
  *	Execute a colon command line.
  *
- * PUBLIC: int v_ex __P((SCR *, VICMD *));
+ * PUBLIC: int v_ex(SCR *, VICMD *);
  */
 int
 v_ex(SCR *sp, VICMD *vp)
@@ -543,7 +543,7 @@ v_ecl(SCR *sp)
  * v_ecl_exec --
  *	Execute a command from a colon command-line window.
  *
- * PUBLIC: int v_ecl_exec __P((SCR *));
+ * PUBLIC: int v_ecl_exec(SCR *);
  */
 int
 v_ecl_exec(SCR *sp)

--- a/vi/v_increment.c
+++ b/vi/v_increment.c
@@ -41,13 +41,13 @@ static CHAR_T * const fmt[] = {
 	L("%#0*lo"),
 };
 
-static void inc_err __P((SCR *, enum nresult));
+static void inc_err(SCR *, enum nresult);
 
 /*
  * v_increment -- [count]#[#+-]
  *	Increment/decrement a keyword number.
  *
- * PUBLIC: int v_increment __P((SCR *, VICMD *));
+ * PUBLIC: int v_increment(SCR *, VICMD *);
  */
 int
 v_increment(SCR *sp, VICMD *vp)

--- a/vi/v_init.c
+++ b/vi/v_init.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: v_init.c,v 10.10 2012/02/11 00:33:46 zy Exp $
  * v_screen_copy --
  *	Copy vi screen.
  *
- * PUBLIC: int v_screen_copy __P((SCR *, SCR *));
+ * PUBLIC: int v_screen_copy(SCR *, SCR *);
  */
 int
 v_screen_copy(SCR *orig, SCR *sp)
@@ -79,7 +79,7 @@ v_screen_copy(SCR *orig, SCR *sp)
  * v_screen_end --
  *	End a vi screen.
  *
- * PUBLIC: int v_screen_end __P((SCR *));
+ * PUBLIC: int v_screen_end(SCR *);
  */
 int
 v_screen_end(SCR *sp)
@@ -110,7 +110,7 @@ v_screen_end(SCR *sp)
  * v_optchange --
  *	Handle change of options for vi.
  *
- * PUBLIC: int v_optchange __P((SCR *, int, char *, u_long *));
+ * PUBLIC: int v_optchange(SCR *, int, char *, u_long *);
  */
 int
 v_optchange(SCR *sp, int offset, char *str, u_long *valp)

--- a/vi/v_itxt.c
+++ b/vi/v_itxt.c
@@ -57,13 +57,13 @@ static const char sccsid[] = "$Id: v_itxt.c,v 10.21 2001/06/25 15:19:32 skimo Ex
 		(void)log_cursor(sp);					\
 }
 
-static u_int32_t set_txt_std __P((SCR *, VICMD *, u_int32_t));
+static u_int32_t set_txt_std(SCR *, VICMD *, u_int32_t);
 
 /*
  * v_iA -- [count]A
  *	Append text to the end of the line.
  *
- * PUBLIC: int v_iA __P((SCR *, VICMD *));
+ * PUBLIC: int v_iA(SCR *, VICMD *);
  */
 int
 v_iA(SCR *sp, VICMD *vp)
@@ -83,7 +83,7 @@ v_iA(SCR *sp, VICMD *vp)
  *	   [count]A
  *	Append text to the cursor position.
  *
- * PUBLIC: int v_ia __P((SCR *, VICMD *));
+ * PUBLIC: int v_ia(SCR *, VICMD *);
  */
 int
 v_ia(SCR *sp, VICMD *vp)
@@ -120,7 +120,7 @@ v_ia(SCR *sp, VICMD *vp)
  * v_iI -- [count]I
  *	Insert text at the first nonblank.
  *
- * PUBLIC: int v_iI __P((SCR *, VICMD *));
+ * PUBLIC: int v_iI(SCR *, VICMD *);
  */
 int
 v_iI(SCR *sp, VICMD *vp)
@@ -139,7 +139,7 @@ v_iI(SCR *sp, VICMD *vp)
  *	   [count]I
  *	Insert text at the cursor position.
  *
- * PUBLIC: int v_ii __P((SCR *, VICMD *));
+ * PUBLIC: int v_ii(SCR *, VICMD *);
  */
 int
 v_ii(SCR *sp, VICMD *vp)
@@ -166,13 +166,13 @@ v_ii(SCR *sp, VICMD *vp)
 }
 
 enum which { o_cmd, O_cmd };
-static int io __P((SCR *, VICMD *, enum which));
+static int io(SCR *, VICMD *, enum which);
 
 /*
  * v_iO -- [count]O
  *	Insert text above this line.
  *
- * PUBLIC: int v_iO __P((SCR *, VICMD *));
+ * PUBLIC: int v_iO(SCR *, VICMD *);
  */
 int
 v_iO(SCR *sp, VICMD *vp)
@@ -184,7 +184,7 @@ v_iO(SCR *sp, VICMD *vp)
  * v_io -- [count]o
  *	Insert text after this line.
  *
- * PUBLIC: int v_io __P((SCR *, VICMD *));
+ * PUBLIC: int v_io(SCR *, VICMD *);
  */
 int
 v_io(SCR *sp, VICMD *vp)
@@ -240,7 +240,7 @@ insert:		p = L("");
  *	       [buffer][count]S
  *	Change command.
  *
- * PUBLIC: int v_change __P((SCR *, VICMD *));
+ * PUBLIC: int v_change(SCR *, VICMD *);
  */
 int
 v_change(SCR *sp, VICMD *vp)
@@ -380,7 +380,7 @@ v_change(SCR *sp, VICMD *vp)
  * v_Replace -- [count]R
  *	Overwrite multiple characters.
  *
- * PUBLIC: int v_Replace __P((SCR *, VICMD *));
+ * PUBLIC: int v_Replace(SCR *, VICMD *);
  */
 int
 v_Replace(SCR *sp, VICMD *vp)
@@ -414,7 +414,7 @@ v_Replace(SCR *sp, VICMD *vp)
  * v_subst -- [buffer][count]s
  *	Substitute characters.
  *
- * PUBLIC: int v_subst __P((SCR *, VICMD *));
+ * PUBLIC: int v_subst(SCR *, VICMD *);
  */
 int
 v_subst(SCR *sp, VICMD *vp)

--- a/vi/v_left.c
+++ b/vi/v_left.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_left.c,v 10.9 2001/06/25 15:19:32 skimo Exp
  * v_left -- [count]^H, [count]h
  *	Move left by columns.
  *
- * PUBLIC: int v_left __P((SCR *, VICMD *));
+ * PUBLIC: int v_left(SCR *, VICMD *);
  */
 int
 v_left(SCR *sp, VICMD *vp)
@@ -66,7 +66,7 @@ v_left(SCR *sp, VICMD *vp)
  * v_cfirst -- [count]_
  *	Move to the first non-blank character in a line.
  *
- * PUBLIC: int v_cfirst __P((SCR *, VICMD *));
+ * PUBLIC: int v_cfirst(SCR *, VICMD *);
  */
 int
 v_cfirst(SCR *sp, VICMD *vp)
@@ -133,7 +133,7 @@ v_cfirst(SCR *sp, VICMD *vp)
  * v_first -- ^
  *	Move to the first non-blank character in this line.
  *
- * PUBLIC: int v_first __P((SCR *, VICMD *));
+ * PUBLIC: int v_first(SCR *, VICMD *);
  */
 int
 v_first(SCR *sp, VICMD *vp)
@@ -195,7 +195,7 @@ v_first(SCR *sp, VICMD *vp)
  *	requested column is past EOL, move to EOL.  The nasty part is
  *	that we have to know character column widths to make this work.
  *
- * PUBLIC: int v_ncol __P((SCR *, VICMD *));
+ * PUBLIC: int v_ncol(SCR *, VICMD *);
  */
 int
 v_ncol(SCR *sp, VICMD *vp)
@@ -255,7 +255,7 @@ v_ncol(SCR *sp, VICMD *vp)
  * v_zero -- 0
  *	Move to the first column on this line.
  *
- * PUBLIC: int v_zero __P((SCR *, VICMD *));
+ * PUBLIC: int v_zero(SCR *, VICMD *);
  */
 int
 v_zero(SCR *sp, VICMD *vp)

--- a/vi/v_mark.c
+++ b/vi/v_mark.c
@@ -26,13 +26,13 @@ static const char sccsid[] = "$Id: v_mark.c,v 10.12 2001/06/25 15:19:32 skimo Ex
 #include "vi.h"
 
 enum which {BQMARK, FQMARK};
-static int mark __P((SCR *, VICMD *, int, enum which));
+static int mark(SCR *, VICMD *, int, enum which);
 
 /*
  * v_mark -- m[a-z]
  *	Set a mark.
  *
- * PUBLIC: int v_mark __P((SCR *, VICMD *));
+ * PUBLIC: int v_mark(SCR *, VICMD *);
  */
 int
 v_mark(SCR *sp, VICMD *vp)
@@ -53,7 +53,7 @@ v_mark(SCR *sp, VICMD *vp)
  * people don't know it and will be delighted that you are able to tell
  * them.
  *
- * PUBLIC: int v_bmark __P((SCR *, VICMD *));
+ * PUBLIC: int v_bmark(SCR *, VICMD *);
  */
 int
 v_bmark(SCR *sp, VICMD *vp)
@@ -67,7 +67,7 @@ v_bmark(SCR *sp, VICMD *vp)
  *
  * Move to the first nonblank character of the line containing the mark.
  *
- * PUBLIC: int v_fmark __P((SCR *, VICMD *));
+ * PUBLIC: int v_fmark(SCR *, VICMD *);
  */
 int
 v_fmark(SCR *sp, VICMD *vp)
@@ -79,7 +79,7 @@ v_fmark(SCR *sp, VICMD *vp)
  * v_emark -- <mouse click>
  *	Mouse mark.
  *
- * PUBLIC: int v_emark __P((SCR *, VICMD *));
+ * PUBLIC: int v_emark(SCR *, VICMD *);
  */
 int
 v_emark(SCR *sp, VICMD *vp)

--- a/vi/v_match.c
+++ b/vi/v_match.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: v_match.c,v 10.11 2012/02/11 00:33:46 zy Exp 
  * v_match -- %
  *	Search to matching character.
  *
- * PUBLIC: int v_match __P((SCR *, VICMD *));
+ * PUBLIC: int v_match(SCR *, VICMD *);
  */
 int
 v_match(SCR *sp, VICMD *vp)
@@ -154,7 +154,7 @@ nomatch:		msgq(sp, M_BERR, "184|No match character on this line");
  * v_buildmcs --
  *	Build the match character list.
  *
- * PUBLIC: int v_buildmcs __P((SCR *, char *));
+ * PUBLIC: int v_buildmcs(SCR *, char *);
  */
 int
 v_buildmcs(SCR *sp, char *str)

--- a/vi/v_paragraph.c
+++ b/vi/v_paragraph.c
@@ -61,7 +61,7 @@ static const char sccsid[] = "$Id: v_paragraph.c,v 10.10 2001/06/25 15:19:32 ski
  * Paragraphs are empty lines after text, formfeed characters, or values
  * from the paragraph or section options.
  *
- * PUBLIC: int v_paragraphf __P((SCR *, VICMD *));
+ * PUBLIC: int v_paragraphf(SCR *, VICMD *);
  */
 int
 v_paragraphf(SCR *sp, VICMD *vp)
@@ -199,7 +199,7 @@ eof:	if (vp->m_start.lno == lno || vp->m_start.lno == lno - 1) {
  * v_paragraphb -- [count]{
  *	Move backward count paragraphs.
  *
- * PUBLIC: int v_paragraphb __P((SCR *, VICMD *));
+ * PUBLIC: int v_paragraphb(SCR *, VICMD *);
  */
 int
 v_paragraphb(SCR *sp, VICMD *vp)
@@ -306,7 +306,7 @@ found:	vp->m_stop.lno = lno;
  * v_buildps --
  *	Build the paragraph command search pattern.
  *
- * PUBLIC: int v_buildps __P((SCR *, char *, char *));
+ * PUBLIC: int v_buildps(SCR *, char *, char *);
  */
 int
 v_buildps(SCR *sp, char *p_p, char *s_p)

--- a/vi/v_put.c
+++ b/vi/v_put.c
@@ -24,13 +24,13 @@ static const char sccsid[] = "$Id: v_put.c,v 10.6 2001/06/25 15:19:34 skimo Exp 
 #include "../common/common.h"
 #include "vi.h"
 
-static void	inc_buf __P((SCR *, VICMD *));
+static void	inc_buf(SCR *, VICMD *);
 
 /*
  * v_Put -- [buffer]P
  *	Insert the contents of the buffer before the cursor.
  *
- * PUBLIC: int v_Put __P((SCR *, VICMD *));
+ * PUBLIC: int v_Put(SCR *, VICMD *);
  */
 int
 v_Put(SCR *sp, VICMD *vp)
@@ -61,7 +61,7 @@ v_Put(SCR *sp, VICMD *vp)
  * v_put -- [buffer]p
  *	Insert the contents of the buffer after the cursor.
  *
- * PUBLIC: int v_put __P((SCR *, VICMD *));
+ * PUBLIC: int v_put(SCR *, VICMD *);
  */
 int
 v_put(SCR *sp, VICMD *vp)

--- a/vi/v_redraw.c
+++ b/vi/v_redraw.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_redraw.c,v 10.7 2001/06/25 15:19:34 skimo E
  * v_redraw -- ^L, ^R
  *	Redraw the screen.
  *
- * PUBLIC: int v_redraw __P((SCR *, VICMD *));
+ * PUBLIC: int v_redraw(SCR *, VICMD *);
  */
 int
 v_redraw(SCR *sp, VICMD *vp)

--- a/vi/v_replace.c
+++ b/vi/v_replace.c
@@ -40,7 +40,7 @@ static const char sccsid[] = "$Id: v_replace.c,v 10.24 2001/06/25 15:19:34 skimo
  * <literal> character, it required three <literal> characters after the
  * command.  This may not be right, but at least it's not insane.
  *
- * PUBLIC: int v_replace __P((SCR *, VICMD *));
+ * PUBLIC: int v_replace(SCR *, VICMD *);
  */
 int
 v_replace(SCR *sp, VICMD *vp)

--- a/vi/v_right.c
+++ b/vi/v_right.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_right.c,v 10.8 2001/06/25 15:19:34 skimo Ex
  * v_right -- [count]' ', [count]l
  *	Move right by columns.
  *
- * PUBLIC: int v_right __P((SCR *, VICMD *));
+ * PUBLIC: int v_right(SCR *, VICMD *);
  */
 int
 v_right(SCR *sp, VICMD *vp)
@@ -78,7 +78,7 @@ eol:		v_eol(sp, NULL);
  * v_dollar -- [count]$
  *	Move to the last column.
  *
- * PUBLIC: int v_dollar __P((SCR *, VICMD *));
+ * PUBLIC: int v_dollar(SCR *, VICMD *);
  */
 int
 v_dollar(SCR *sp, VICMD *vp)

--- a/vi/v_screen.c
+++ b/vi/v_screen.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_screen.c,v 10.12 2001/06/25 15:19:34 skimo 
  * v_screen -- ^W
  *	Switch screens.
  *
- * PUBLIC: int v_screen __P((SCR *, VICMD *));
+ * PUBLIC: int v_screen(SCR *, VICMD *);
  */
 int
 v_screen(SCR *sp, VICMD *vp)

--- a/vi/v_scroll.c
+++ b/vi/v_scroll.c
@@ -25,7 +25,7 @@ static const char sccsid[] = "$Id: v_scroll.c,v 10.12 2001/06/25 15:19:34 skimo 
 #include "../common/common.h"
 #include "vi.h"
 
-static void goto_adjust __P((VICMD *));
+static void goto_adjust(VICMD *);
 
 /*
  * The historic vi had a problem in that all movements were by physical
@@ -64,7 +64,7 @@ static void goto_adjust __P((VICMD *));
  *	Go to first non-blank character of the line count, the last line
  *	of the file by default.
  *
- * PUBLIC: int v_lgoto __P((SCR *, VICMD *));
+ * PUBLIC: int v_lgoto(SCR *, VICMD *);
  */
 int
 v_lgoto(SCR *sp, VICMD *vp)
@@ -101,7 +101,7 @@ v_lgoto(SCR *sp, VICMD *vp)
  *	Move to the first non-blank character of the logical line
  *	count - 1 from the top of the screen, 0 by default.
  *
- * PUBLIC: int v_home __P((SCR *, VICMD *));
+ * PUBLIC: int v_home(SCR *, VICMD *);
  */
 int
 v_home(SCR *sp, VICMD *vp)
@@ -118,7 +118,7 @@ v_home(SCR *sp, VICMD *vp)
  *	Move to the first non-blank character of the logical line
  *	in the middle of the screen.
  *
- * PUBLIC: int v_middle __P((SCR *, VICMD *));
+ * PUBLIC: int v_middle(SCR *, VICMD *);
  */
 int
 v_middle(SCR *sp, VICMD *vp)
@@ -139,7 +139,7 @@ v_middle(SCR *sp, VICMD *vp)
  *	Move to the first non-blank character of the logical line
  *	count - 1 from the bottom of the screen, 0 by default.
  *
- * PUBLIC: int v_bottom __P((SCR *, VICMD *));
+ * PUBLIC: int v_bottom(SCR *, VICMD *);
  */
 int
 v_bottom(SCR *sp, VICMD *vp)
@@ -202,7 +202,7 @@ goto_adjust(VICMD *vp)
  * v_up -- [count]^P, [count]k, [count]-
  *	Move up by lines.
  *
- * PUBLIC: int v_up __P((SCR *, VICMD *));
+ * PUBLIC: int v_up(SCR *, VICMD *);
  */
 int
 v_up(SCR *sp, VICMD *vp)
@@ -224,7 +224,7 @@ v_up(SCR *sp, VICMD *vp)
  *	In a script window, send the line to the shell.
  *	In a regular window, move down by lines.
  *
- * PUBLIC: int v_cr __P((SCR *, VICMD *));
+ * PUBLIC: int v_cr(SCR *, VICMD *);
  */
 int
 v_cr(SCR *sp, VICMD *vp)
@@ -245,7 +245,7 @@ v_cr(SCR *sp, VICMD *vp)
  * v_down -- [count]^J, [count]^N, [count]j, [count]^M, [count]+
  *	Move down by lines.
  *
- * PUBLIC: int v_down __P((SCR *, VICMD *));
+ * PUBLIC: int v_down(SCR *, VICMD *);
  */
 int
 v_down(SCR *sp, VICMD *vp)
@@ -266,7 +266,7 @@ v_down(SCR *sp, VICMD *vp)
  * v_hpageup -- [count]^U
  *	Page up half screens.
  *
- * PUBLIC: int v_hpageup __P((SCR *, VICMD *));
+ * PUBLIC: int v_hpageup(SCR *, VICMD *);
  */
 int
 v_hpageup(SCR *sp, VICMD *vp)
@@ -290,7 +290,7 @@ v_hpageup(SCR *sp, VICMD *vp)
  * v_hpagedown -- [count]^D
  *	Page down half screens.
  *
- * PUBLIC: int v_hpagedown __P((SCR *, VICMD *));
+ * PUBLIC: int v_hpagedown(SCR *, VICMD *);
  */
 int
 v_hpagedown(SCR *sp, VICMD *vp)
@@ -318,7 +318,7 @@ v_hpagedown(SCR *sp, VICMD *vp)
  * if EOF was already displayed on the screen.  This implementation does
  * move to EOF in that case, making ^F more like the the historic ^D.
  *
- * PUBLIC: int v_pagedown __P((SCR *, VICMD *));
+ * PUBLIC: int v_pagedown(SCR *, VICMD *);
  */
 int
 v_pagedown(SCR *sp, VICMD *vp)
@@ -364,7 +364,7 @@ v_pagedown(SCR *sp, VICMD *vp)
  * if SOF was already displayed on the screen.  This implementation does
  * move to SOF in that case, making ^B more like the the historic ^U.
  *
- * PUBLIC: int v_pageup __P((SCR *, VICMD *));
+ * PUBLIC: int v_pageup(SCR *, VICMD *);
  */
 int
 v_pageup(SCR *sp, VICMD *vp)
@@ -410,7 +410,7 @@ v_pageup(SCR *sp, VICMD *vp)
  * v_lineup -- [count]^Y
  *	Page up by lines.
  *
- * PUBLIC: int v_lineup __P((SCR *, VICMD *));
+ * PUBLIC: int v_lineup(SCR *, VICMD *);
  */
 int
 v_lineup(SCR *sp, VICMD *vp)
@@ -430,7 +430,7 @@ v_lineup(SCR *sp, VICMD *vp)
  * v_linedown -- [count]^E
  *	Page down by lines.
  *
- * PUBLIC: int v_linedown __P((SCR *, VICMD *));
+ * PUBLIC: int v_linedown(SCR *, VICMD *);
  */
 int
 v_linedown(SCR *sp, VICMD *vp)

--- a/vi/v_search.c
+++ b/vi/v_search.c
@@ -28,14 +28,14 @@ static const char sccsid[] = "$Id: v_search.c,v 10.31 2012/02/08 07:26:59 zy Exp
 #include "../common/common.h"
 #include "vi.h"
 
-static int v_exaddr __P((SCR *, VICMD *, dir_t));
-static int v_search __P((SCR *, VICMD *, CHAR_T *, size_t, u_int, dir_t));
+static int v_exaddr(SCR *, VICMD *, dir_t);
+static int v_search(SCR *, VICMD *, CHAR_T *, size_t, u_int, dir_t);
 
 /*
  * v_srch -- [count]?RE[? offset]
  *	Ex address search backward.
  *
- * PUBLIC: int v_searchb __P((SCR *, VICMD *));
+ * PUBLIC: int v_searchb(SCR *, VICMD *);
  */
 int
 v_searchb(SCR *sp, VICMD *vp)
@@ -47,7 +47,7 @@ v_searchb(SCR *sp, VICMD *vp)
  * v_searchf -- [count]/RE[/ offset]
  *	Ex address search forward.
  *
- * PUBLIC: int v_searchf __P((SCR *, VICMD *));
+ * PUBLIC: int v_searchf(SCR *, VICMD *);
  */
 int
 v_searchf(SCR *sp, VICMD *vp)
@@ -278,7 +278,7 @@ err2:	vp->m_final.lno = s_lno;
  * v_searchN -- N
  *	Reverse last search.
  *
- * PUBLIC: int v_searchN __P((SCR *, VICMD *));
+ * PUBLIC: int v_searchN(SCR *, VICMD *);
  */
 int
 v_searchN(SCR *sp, VICMD *vp)
@@ -303,7 +303,7 @@ v_searchN(SCR *sp, VICMD *vp)
  * v_searchn -- n
  *	Repeat last search.
  *
- * PUBLIC: int v_searchn __P((SCR *, VICMD *));
+ * PUBLIC: int v_searchn(SCR *, VICMD *);
  */
 int
 v_searchn(SCR *sp, VICMD *vp)
@@ -338,7 +338,7 @@ is_special(CHAR_T c)
  * v_searchw -- [count]^A
  *	Search for the word under the cursor.
  *
- * PUBLIC: int v_searchw __P((SCR *, VICMD *));
+ * PUBLIC: int v_searchw(SCR *, VICMD *);
  */
 int
 v_searchw(SCR *sp, VICMD *vp)
@@ -450,7 +450,7 @@ v_search(SCR *sp, VICMD *vp, CHAR_T *ptrn, size_t plen, u_int flags, dir_t dir)
  * 'k' and put would no longer work correctly.  In any case, we try to do
  * the right thing, but it's not going to exactly match historic practice.
  *
- * PUBLIC: int v_correct __P((SCR *, VICMD *, int));
+ * PUBLIC: int v_correct(SCR *, VICMD *, int);
  */
 int
 v_correct(SCR *sp, VICMD *vp, int isdelta)

--- a/vi/v_section.c
+++ b/vi/v_section.c
@@ -59,7 +59,7 @@ static const char sccsid[] = "$Id: v_section.c,v 10.10 2001/06/25 15:19:35 skimo
  * a section, it did NOT include the matched line.  If it matched a }, it
  * did include the line.  No clue why.
  *
- * PUBLIC: int v_sectionf __P((SCR *, VICMD *));
+ * PUBLIC: int v_sectionf(SCR *, VICMD *);
  */
 int
 v_sectionf(SCR *sp, VICMD *vp)
@@ -166,7 +166,7 @@ ret2:	if (ISMOTION(vp)) {
  * v_sectionb -- [count][[
  *	Move backward count sections/functions.
  *
- * PUBLIC: int v_sectionb __P((SCR *, VICMD *));
+ * PUBLIC: int v_sectionb(SCR *, VICMD *);
  */
 int
 v_sectionb(SCR *sp, VICMD *vp)

--- a/vi/v_sentence.c
+++ b/vi/v_sentence.c
@@ -49,7 +49,7 @@ static const char sccsid[] = "$Id: v_sentence.c,v 10.9 2001/06/25 15:19:35 skimo
  * v_sentencef -- [count])
  *	Move forward count sentences.
  *
- * PUBLIC: int v_sentencef __P((SCR *, VICMD *));
+ * PUBLIC: int v_sentencef(SCR *, VICMD *);
  */
 int
 v_sentencef(SCR *sp, VICMD *vp)
@@ -188,7 +188,7 @@ okret:	vp->m_stop.lno = cs.cs_lno;
  * v_sentenceb -- [count](
  *	Move backward count sentences.
  *
- * PUBLIC: int v_sentenceb __P((SCR *, VICMD *));
+ * PUBLIC: int v_sentenceb(SCR *, VICMD *);
  */
 int
 v_sentenceb(SCR *sp, VICMD *vp)

--- a/vi/v_status.c
+++ b/vi/v_status.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_status.c,v 10.10 2001/06/25 15:19:35 skimo 
  * v_status -- ^G
  *	Show the file status.
  *
- * PUBLIC: int v_status __P((SCR *, VICMD *));
+ * PUBLIC: int v_status(SCR *, VICMD *);
  */
 int
 v_status(SCR *sp, VICMD *vp)

--- a/vi/v_txt.c
+++ b/vi/v_txt.c
@@ -29,25 +29,25 @@ static const char sccsid[] = "$Id: v_txt.c,v 11.5 2013/05/19 20:37:45 bentley Ex
 #include "../common/common.h"
 #include "vi.h"
 
-static int	 txt_abbrev __P((SCR *, TEXT *, CHAR_T *, int, int *, int *));
-static void	 txt_ai_resolve __P((SCR *, TEXT *, int *));
-static TEXT	*txt_backup __P((SCR *, TEXTH *, TEXT *, u_int32_t *));
-static int	 txt_dent __P((SCR *, TEXT *, int));
-static int	 txt_emark __P((SCR *, TEXT *, size_t));
-static void	 txt_err __P((SCR *, TEXTH *));
-static int	 txt_fc __P((SCR *, TEXT *, int *));
-static int	 txt_fc_col __P((SCR *, int, ARGS **));
-static int	 txt_hex __P((SCR *, TEXT *));
-static int	 txt_insch __P((SCR *, TEXT *, CHAR_T *, u_int));
-static int	 txt_isrch __P((SCR *, VICMD *, TEXT *, u_int8_t *));
-static int	 txt_map_end __P((SCR *));
-static int	 txt_map_init __P((SCR *));
-static int	 txt_margin __P((SCR *, TEXT *, TEXT *, int *, u_int32_t));
-static void	 txt_nomorech __P((SCR *));
-static void	 txt_Rresolve __P((SCR *, TEXTH *, TEXT *, const size_t));
-static int	 txt_resolve __P((SCR *, TEXTH *, u_int32_t));
-static int	 txt_showmatch __P((SCR *, TEXT *));
-static void	 txt_unmap __P((SCR *, TEXT *, u_int32_t *));
+static int	 txt_abbrev(SCR *, TEXT *, CHAR_T *, int, int *, int *);
+static void	 txt_ai_resolve(SCR *, TEXT *, int *);
+static TEXT	*txt_backup(SCR *, TEXTH *, TEXT *, u_int32_t *);
+static int	 txt_dent(SCR *, TEXT *, int);
+static int	 txt_emark(SCR *, TEXT *, size_t);
+static void	 txt_err(SCR *, TEXTH *);
+static int	 txt_fc(SCR *, TEXT *, int *);
+static int	 txt_fc_col(SCR *, int, ARGS **);
+static int	 txt_hex(SCR *, TEXT *);
+static int	 txt_insch(SCR *, TEXT *, CHAR_T *, u_int);
+static int	 txt_isrch(SCR *, VICMD *, TEXT *, u_int8_t *);
+static int	 txt_map_end(SCR *);
+static int	 txt_map_init(SCR *);
+static int	 txt_margin(SCR *, TEXT *, TEXT *, int *, u_int32_t);
+static void	 txt_nomorech(SCR *);
+static void	 txt_Rresolve(SCR *, TEXTH *, TEXT *, const size_t);
+static int	 txt_resolve(SCR *, TEXTH *, u_int32_t);
+static int	 txt_showmatch(SCR *, TEXT *);
+static void	 txt_unmap(SCR *, TEXT *, u_int32_t *);
 
 /* Cursor character (space is hard to track on the screen). */
 #if defined(DEBUG) && 0
@@ -59,7 +59,7 @@ static void	 txt_unmap __P((SCR *, TEXT *, u_int32_t *));
  * v_tcmd --
  *	Fill a buffer from the terminal for vi.
  *
- * PUBLIC: int v_tcmd __P((SCR *, VICMD *, ARG_CHAR_T, u_int));
+ * PUBLIC: int v_tcmd(SCR *, VICMD *, ARG_CHAR_T, u_int);
  */
 int
 v_tcmd(SCR *sp, VICMD *vp, ARG_CHAR_T prompt, u_int flags)
@@ -234,8 +234,8 @@ txt_map_end(SCR *sp)
  * v_txt --
  *	Vi text input.
  *
- * PUBLIC: int v_txt __P((SCR *, VICMD *, MARK *,
- * PUBLIC:    const CHAR_T *, size_t, ARG_CHAR_T, recno_t, u_long, u_int32_t));
+ * PUBLIC: int v_txt(SCR *, VICMD *, MARK *,
+ * PUBLIC:    const CHAR_T *, size_t, ARG_CHAR_T, recno_t, u_long, u_int32_t);
  */
 int
 v_txt(
@@ -1760,7 +1760,7 @@ txt_ai_resolve(SCR *sp, TEXT *tp, int *changedp)
  *	Handle autoindent.  If aitp isn't NULL, use it, otherwise,
  *	retrieve the line.
  *
- * PUBLIC: int v_txt_auto __P((SCR *, recno_t, TEXT *, size_t, TEXT *));
+ * PUBLIC: int v_txt_auto(SCR *, recno_t, TEXT *, size_t, TEXT *);
  */
 int
 v_txt_auto(SCR *sp, recno_t lno, TEXT *aitp, size_t len, TEXT *tp)

--- a/vi/v_ulcase.c
+++ b/vi/v_ulcase.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_ulcase.c,v 10.12 2011/12/02 19:58:32 zy Exp
 #include "../common/common.h"
 #include "vi.h"
 
-static int ulcase __P((SCR *, recno_t, CHAR_T *, size_t, size_t, size_t));
+static int ulcase(SCR *, recno_t, CHAR_T *, size_t, size_t, size_t);
 
 /*
  * v_ulcase -- [count]~
@@ -44,7 +44,7 @@ static int ulcase __P((SCR *, recno_t, CHAR_T *, size_t, size_t, size_t));
  * if there had been an associated motion, but it's too late to make
  * that the default now.
  *
- * PUBLIC: int v_ulcase __P((SCR *, VICMD *));
+ * PUBLIC: int v_ulcase(SCR *, VICMD *);
  */
 int
 v_ulcase(SCR *sp, VICMD *vp)
@@ -102,7 +102,7 @@ v_ulcase(SCR *sp, VICMD *vp)
  * v_mulcase -- [count]~[count]motion
  *	Toggle upper & lower case letters over a range.
  *
- * PUBLIC: int v_mulcase __P((SCR *, VICMD *));
+ * PUBLIC: int v_mulcase(SCR *, VICMD *);
  */
 int
 v_mulcase(SCR *sp, VICMD *vp)

--- a/vi/v_undo.c
+++ b/vi/v_undo.c
@@ -31,7 +31,7 @@ static const char sccsid[] = "$Id: v_undo.c,v 10.6 2001/06/25 15:19:36 skimo Exp
  * v_Undo -- U
  *	Undo changes to this line.
  *
- * PUBLIC: int v_Undo __P((SCR *, VICMD *));
+ * PUBLIC: int v_Undo(SCR *, VICMD *);
  */
 int
 v_Undo(SCR *sp, VICMD *vp)
@@ -65,7 +65,7 @@ v_Undo(SCR *sp, VICMD *vp)
  * v_undo -- u
  *	Undo the last change.
  *
- * PUBLIC: int v_undo __P((SCR *, VICMD *));
+ * PUBLIC: int v_undo(SCR *, VICMD *);
  */
 int
 v_undo(SCR *sp, VICMD *vp)

--- a/vi/v_util.c
+++ b/vi/v_util.c
@@ -32,7 +32,7 @@ static const char sccsid[] = "$Id: v_util.c,v 10.14 2001/06/25 15:19:36 skimo Ex
  * v_eof --
  *	Vi end-of-file error.
  *
- * PUBLIC: void v_eof __P((SCR *, MARK *));
+ * PUBLIC: void v_eof(SCR *, MARK *);
  */
 void
 v_eof(SCR *sp, MARK *mp)
@@ -55,7 +55,7 @@ v_eof(SCR *sp, MARK *mp)
  * v_eol --
  *	Vi end-of-line error.
  *
- * PUBLIC: void v_eol __P((SCR *, MARK *));
+ * PUBLIC: void v_eol(SCR *, MARK *);
  */
 void
 v_eol(SCR *sp, MARK *mp)
@@ -78,7 +78,7 @@ v_eol(SCR *sp, MARK *mp)
  * v_nomove --
  *	Vi no cursor movement error.
  *
- * PUBLIC: void v_nomove __P((SCR *));
+ * PUBLIC: void v_nomove(SCR *);
  */
 void
 v_nomove(SCR *sp)
@@ -90,7 +90,7 @@ v_nomove(SCR *sp)
  * v_sof --
  *	Vi start-of-file error.
  *
- * PUBLIC: void v_sof __P((SCR *, MARK *));
+ * PUBLIC: void v_sof(SCR *, MARK *);
  */
 void
 v_sof(SCR *sp, MARK *mp)
@@ -105,7 +105,7 @@ v_sof(SCR *sp, MARK *mp)
  * v_sol --
  *	Vi start-of-line error.
  *
- * PUBLIC: void v_sol __P((SCR *));
+ * PUBLIC: void v_sol(SCR *);
  */
 void
 v_sol(SCR *sp)
@@ -117,7 +117,7 @@ v_sol(SCR *sp)
  * v_isempty --
  *	Return if the line contains nothing but white-space characters.
  *
- * PUBLIC: int v_isempty __P((CHAR_T *, size_t));
+ * PUBLIC: int v_isempty(CHAR_T *, size_t);
  */
 int
 v_isempty(CHAR_T *p, size_t len)
@@ -132,7 +132,7 @@ v_isempty(CHAR_T *p, size_t len)
  * v_emsg --
  *	Display a few common vi messages.
  *
- * PUBLIC: void v_emsg __P((SCR *, char *, vim_t));
+ * PUBLIC: void v_emsg(SCR *, char *, vim_t);
  */
 void
 v_emsg(SCR *sp, char *p, vim_t which)

--- a/vi/v_word.c
+++ b/vi/v_word.c
@@ -66,15 +66,15 @@ static const char sccsid[] = "$Id: v_word.c,v 10.7 2011/12/27 00:49:31 zy Exp $"
 
 enum which {BIGWORD, LITTLEWORD};
 
-static int bword __P((SCR *, VICMD *, enum which));
-static int eword __P((SCR *, VICMD *, enum which));
-static int fword __P((SCR *, VICMD *, enum which));
+static int bword(SCR *, VICMD *, enum which);
+static int eword(SCR *, VICMD *, enum which);
+static int fword(SCR *, VICMD *, enum which);
 
 /*
  * v_wordW -- [count]W
  *	Move forward a bigword at a time.
  *
- * PUBLIC: int v_wordW __P((SCR *, VICMD *));
+ * PUBLIC: int v_wordW(SCR *, VICMD *);
  */
 int
 v_wordW(SCR *sp, VICMD *vp)
@@ -86,7 +86,7 @@ v_wordW(SCR *sp, VICMD *vp)
  * v_wordw -- [count]w
  *	Move forward a word at a time.
  *
- * PUBLIC: int v_wordw __P((SCR *, VICMD *));
+ * PUBLIC: int v_wordw(SCR *, VICMD *);
  */
 int
 v_wordw(SCR *sp, VICMD *vp)
@@ -234,7 +234,7 @@ ret:	if (!ISMOTION(vp) &&
  * v_wordE -- [count]E
  *	Move forward to the end of the bigword.
  *
- * PUBLIC: int v_wordE __P((SCR *, VICMD *));
+ * PUBLIC: int v_wordE(SCR *, VICMD *);
  */
 int
 v_wordE(SCR *sp, VICMD *vp)
@@ -246,7 +246,7 @@ v_wordE(SCR *sp, VICMD *vp)
  * v_worde -- [count]e
  *	Move forward to the end of the word.
  *
- * PUBLIC: int v_worde __P((SCR *, VICMD *));
+ * PUBLIC: int v_worde(SCR *, VICMD *);
  */
 int
 v_worde(SCR *sp, VICMD *vp)
@@ -380,7 +380,7 @@ ret:	if (!ISMOTION(vp) &&
  * v_WordB -- [count]B
  *	Move backward a bigword at a time.
  *
- * PUBLIC: int v_wordB __P((SCR *, VICMD *));
+ * PUBLIC: int v_wordB(SCR *, VICMD *);
  */
 int
 v_wordB(SCR *sp, VICMD *vp)
@@ -392,7 +392,7 @@ v_wordB(SCR *sp, VICMD *vp)
  * v_wordb -- [count]b
  *	Move backward a word at a time.
  *
- * PUBLIC: int v_wordb __P((SCR *, VICMD *));
+ * PUBLIC: int v_wordb(SCR *, VICMD *);
  */
 int
 v_wordb(SCR *sp, VICMD *vp)

--- a/vi/v_xchar.c
+++ b/vi/v_xchar.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_xchar.c,v 10.10 2001/06/25 15:19:36 skimo E
  * v_xchar -- [buffer] [count]x
  *	Deletes the character(s) on which the cursor sits.
  *
- * PUBLIC: int v_xchar __P((SCR *, VICMD *));
+ * PUBLIC: int v_xchar(SCR *, VICMD *);
  */
 int
 v_xchar(SCR *sp, VICMD *vp)
@@ -75,7 +75,7 @@ nodel:		msgq(sp, M_BERR, "206|No characters to delete");
  *	Deletes the character(s) immediately before the current cursor
  *	position.
  *
- * PUBLIC: int v_Xchar __P((SCR *, VICMD *));
+ * PUBLIC: int v_Xchar(SCR *, VICMD *);
  */
 int
 v_Xchar(SCR *sp, VICMD *vp)

--- a/vi/v_yank.c
+++ b/vi/v_yank.c
@@ -39,7 +39,7 @@ static const char sccsid[] = "$Id: v_yank.c,v 10.10 2001/06/25 15:19:36 skimo Ex
  * to the line and column marked by a.  Hopefully, the motion component code
  * got it right...   Unlike delete, we make no adjustments here.
  *
- * PUBLIC: int v_yank __P((SCR *, VICMD *));
+ * PUBLIC: int v_yank(SCR *, VICMD *);
  */
 int
 v_yank(SCR *sp, VICMD *vp)

--- a/vi/v_z.c
+++ b/vi/v_z.c
@@ -28,7 +28,7 @@ static const char sccsid[] = "$Id: v_z.c,v 10.13 2011/12/02 17:26:59 zy Exp $";
  * v_z -- [count]z[count][-.+^<CR>]
  *	Move the screen.
  *
- * PUBLIC: int v_z __P((SCR *, VICMD *));
+ * PUBLIC: int v_z(SCR *, VICMD *);
  */
 int
 v_z(SCR *sp, VICMD *vp)
@@ -131,7 +131,7 @@ v_z(SCR *sp, VICMD *vp)
  * vs_crel --
  *	Change the relative size of the current screen.
  *
- * PUBLIC: int vs_crel __P((SCR *, long));
+ * PUBLIC: int vs_crel(SCR *, long);
  */
 int
 vs_crel(SCR *sp, long int count)

--- a/vi/v_zexit.c
+++ b/vi/v_zexit.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: v_zexit.c,v 10.7 2001/06/25 15:19:37 skimo Ex
  * v_zexit -- ZZ
  *	Save the file and exit.
  *
- * PUBLIC: int v_zexit __P((SCR *, VICMD *));
+ * PUBLIC: int v_zexit(SCR *, VICMD *);
  */
 int
 v_zexit(SCR *sp, VICMD *vp)

--- a/vi/vi.c
+++ b/vi/vi.c
@@ -34,16 +34,16 @@ typedef enum {
 } gcret_t;
 
 static VIKEYS const
-	       *v_alias __P((SCR *, VICMD *, VIKEYS const *));
-static gcret_t	v_cmd __P((SCR *, VICMD *, VICMD *, VICMD *, int *, int *));
-static int	v_count __P((SCR *, ARG_CHAR_T, u_long *));
-static void	v_dtoh __P((SCR *));
-static int	v_init __P((SCR *));
-static gcret_t	v_key __P((SCR *, int, EVENT *, u_int32_t));
-static int	v_motion __P((SCR *, VICMD *, VICMD *, int *));
+	       *v_alias(SCR *, VICMD *, VIKEYS const *);
+static gcret_t	v_cmd(SCR *, VICMD *, VICMD *, VICMD *, int *, int *);
+static int	v_count(SCR *, ARG_CHAR_T, u_long *);
+static void	v_dtoh(SCR *);
+static int	v_init(SCR *);
+static gcret_t	v_key(SCR *, int, EVENT *, u_int32_t);
+static int	v_motion(SCR *, VICMD *, VICMD *, int *);
 
 #if defined(DEBUG) && defined(COMLOG)
-static void	v_comlog __P((SCR *, VICMD *));
+static void	v_comlog(SCR *, VICMD *);
 #endif
 
 /*
@@ -58,7 +58,7 @@ static void	v_comlog __P((SCR *, VICMD *));
  * vi --
  * 	Main vi command loop.
  *
- * PUBLIC: int vi __P((SCR **));
+ * PUBLIC: int vi(SCR **);
  */
 int
 vi(SCR **spp)
@@ -1031,7 +1031,7 @@ v_dtoh(SCR *sp)
  * v_curword --
  *	Get the word (tagstring, actually) the cursor is on.
  *
- * PUBLIC: int v_curword __P((SCR *));
+ * PUBLIC: int v_curword(SCR *);
  */
 int
 v_curword(SCR *sp)

--- a/vi/vi.h
+++ b/vi/vi.h
@@ -126,7 +126,7 @@ typedef struct _vicmd {
 
 /* Vi command table structure. */
 struct _vikeys {			/* Underlying function. */
-	int	 (*func) __P((SCR *, VICMD *));
+	int	 (*func)(SCR *, VICMD *);
 #define	V_ABS		0x00004000	/* Absolute movement, set '' mark. */
 #define	V_ABS_C		0x00008000	/* V_ABS: if the line/column changed. */
 #define	V_ABS_L		0x00010000	/* V_ABS: if the line changed. */
@@ -161,12 +161,12 @@ typedef struct _vcs {
 	int	 cs_flags;		/* Return flags. */
 } VCS;
 
-int	cs_bblank __P((SCR *, VCS *));
-int	cs_fblank __P((SCR *, VCS *));
-int	cs_fspace __P((SCR *, VCS *));
-int	cs_init __P((SCR *, VCS *));
-int	cs_next __P((SCR *, VCS *));
-int	cs_prev __P((SCR *, VCS *));
+int	cs_bblank(SCR *, VCS *);
+int	cs_fblank(SCR *, VCS *);
+int	cs_fspace(SCR *, VCS *);
+int	cs_init(SCR *, VCS *);
+int	cs_next(SCR *, VCS *);
+int	cs_prev(SCR *, VCS *);
 
 /*
  * We use a single "window" for each set of vi screens.  The model would be

--- a/vi/vs_line.c
+++ b/vi/vs_line.c
@@ -35,7 +35,7 @@ static const char sccsid[] = "$Id: vs_line.c,v 10.40 2012/02/13 19:22:25 zy Exp 
  * vs_line --
  *	Update one line on the screen.
  *
- * PUBLIC: int vs_line __P((SCR *, SMAP *, size_t *, size_t *));
+ * PUBLIC: int vs_line(SCR *, SMAP *, size_t *, size_t *);
  */
 int
 vs_line(SCR *sp, SMAP *smp, size_t *yp, size_t *xp)
@@ -482,7 +482,7 @@ ret1:	(void)gp->scr_move(sp, oldy, oldx);
  * vs_number --
  *	Repaint the numbers on all the lines.
  *
- * PUBLIC: int vs_number __P((SCR *));
+ * PUBLIC: int vs_number(SCR *);
  */
 int
 vs_number(SCR *sp)

--- a/vi/vs_msg.c
+++ b/vi/vs_msg.c
@@ -37,11 +37,11 @@ typedef enum {
 					 */
 } sw_t;
 
-static void	vs_divider __P((SCR *));
-static void	vs_msgsave __P((SCR *, mtype_t, char *, size_t));
-static void	vs_output __P((SCR *, mtype_t, const char *, int));
-static void	vs_scroll __P((SCR *, int *, sw_t));
-static void	vs_wait __P((SCR *, int *, sw_t));
+static void	vs_divider(SCR *);
+static void	vs_msgsave(SCR *, mtype_t, char *, size_t);
+static void	vs_output(SCR *, mtype_t, const char *, int);
+static void	vs_scroll(SCR *, int *, sw_t);
+static void	vs_wait(SCR *, int *, sw_t);
 
 /*
  * vs_busy --
@@ -53,7 +53,7 @@ static void	vs_wait __P((SCR *, int *, sw_t));
  * messages, e.g. X11 clock icons, should set their scr_busy function to the
  * correct function before calling the main editor routine.
  *
- * PUBLIC: void vs_busy __P((SCR *, const char *, busy_t));
+ * PUBLIC: void vs_busy(SCR *, const char *, busy_t);
  */
 void
 vs_busy(SCR *sp, const char *msg, busy_t btype)
@@ -142,7 +142,7 @@ vs_busy(SCR *sp, const char *msg, busy_t btype)
  * vs_home --
  *	Home the cursor to the bottom row, left-most column.
  *
- * PUBLIC: void vs_home __P((SCR *));
+ * PUBLIC: void vs_home(SCR *);
  */
 void
 vs_home(SCR *sp)
@@ -155,7 +155,7 @@ vs_home(SCR *sp)
  * vs_update --
  *	Update a command.
  *
- * PUBLIC: void vs_update __P((SCR *, const char *, const CHAR_T *));
+ * PUBLIC: void vs_update(SCR *, const char *, const CHAR_T *);
  */
 void
 vs_update(SCR *sp, const char *m1, const CHAR_T *m2)
@@ -225,7 +225,7 @@ vs_update(SCR *sp, const char *m1, const CHAR_T *m2)
  * alternate method of displaying messages, e.g. dialog boxes, should set their
  * scr_msg function to the correct function before calling the editor.
  *
- * PUBLIC: void vs_msg __P((SCR *, mtype_t, char *, size_t));
+ * PUBLIC: void vs_msg(SCR *, mtype_t, char *, size_t);
  */
 void
 vs_msg(SCR *sp, mtype_t mtype, char *line, size_t len)
@@ -506,7 +506,7 @@ vs_output(SCR *sp, mtype_t mtype, const char *line, int llen)
  * This routine is called when exiting a colon command to resolve any ex
  * output that may have occurred.
  *
- * PUBLIC: int vs_ex_resolve __P((SCR *, int *));
+ * PUBLIC: int vs_ex_resolve(SCR *, int *);
  */
 int
 vs_ex_resolve(SCR *sp, int *continuep)
@@ -630,7 +630,7 @@ vs_ex_resolve(SCR *sp, int *continuep)
  * vs_resolve --
  *	Deal with message output.
  *
- * PUBLIC: int vs_resolve __P((SCR *, SCR *, int));
+ * PUBLIC: int vs_resolve(SCR *, SCR *, int);
  */
 int
 vs_resolve(SCR *sp, SCR *csp, int forcewait)

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -30,14 +30,14 @@ static const char sccsid[] = "$Id: vs_refresh.c,v 10.53 2013/11/01 11:57:36 zy E
 #define	UPDATE_CURSOR	0x01			/* Update the cursor. */
 #define	UPDATE_SCREEN	0x02			/* Flush to screen. */
 
-static void	vs_modeline __P((SCR *));
-static int	vs_paint __P((SCR *, u_int));
+static void	vs_modeline(SCR *);
+static int	vs_paint(SCR *, u_int);
 
 /*
  * v_repaint --
  *	Repaint selected lines from the screen.
  *
- * PUBLIC: int vs_repaint __P((SCR *, EVENT *));
+ * PUBLIC: int vs_repaint(SCR *, EVENT *);
  */
 int
 vs_repaint(
@@ -59,7 +59,7 @@ vs_repaint(
  * vs_refresh --
  *	Refresh all screens.
  *
- * PUBLIC: int vs_refresh __P((SCR *, int));
+ * PUBLIC: int vs_refresh(SCR *, int);
  */
 int
 vs_refresh(

--- a/vi/vs_relative.c
+++ b/vi/vs_relative.c
@@ -29,7 +29,7 @@ static const char sccsid[] = "$Id: vs_relative.c,v 10.19 2011/12/01 15:22:59 zy 
  * vs_column --
  *	Return the logical column of the cursor in the line.
  *
- * PUBLIC: int vs_column __P((SCR *, size_t *));
+ * PUBLIC: int vs_column(SCR *, size_t *);
  */
 int
 vs_column(SCR *sp, size_t *colp)
@@ -50,7 +50,7 @@ vs_column(SCR *sp, size_t *colp)
  *	the physical character column within the line, including space
  *	required for the O_NUMBER and O_LIST options.
  *
- * PUBLIC: size_t vs_screens __P((SCR *, recno_t, size_t *));
+ * PUBLIC: size_t vs_screens(SCR *, recno_t, size_t *);
  */
 size_t
 vs_screens(SCR *sp, recno_t lno, size_t *cnop)
@@ -93,7 +93,7 @@ vs_screens(SCR *sp, recno_t lno, size_t *cnop)
  *	Return the screen columns necessary to display the line, or,
  *	if specified, the physical character column within the line.
  *
- * PUBLIC: size_t vs_columns __P((SCR *, CHAR_T *, recno_t, size_t *, size_t *));
+ * PUBLIC: size_t vs_columns(SCR *, CHAR_T *, recno_t, size_t *, size_t *);
  */
 size_t
 vs_columns(SCR *sp, CHAR_T *lp, recno_t lno, size_t *cnop, size_t *diffp)
@@ -192,7 +192,7 @@ done:		if (diffp != NULL)		/* XXX */
  *	character closest to the currently most attractive character
  *	position (which is stored as a screen column).
  *
- * PUBLIC: size_t vs_rcm __P((SCR *, recno_t, int));
+ * PUBLIC: size_t vs_rcm(SCR *, recno_t, int);
  */
 size_t
 vs_rcm(SCR *sp, recno_t lno, int islast)
@@ -218,7 +218,7 @@ vs_rcm(SCR *sp, recno_t lno, int islast)
  *	Return the physical column from the line that will display a
  *	character closest to the specified screen column.
  *
- * PUBLIC: size_t vs_colpos __P((SCR *, recno_t, size_t));
+ * PUBLIC: size_t vs_colpos(SCR *, recno_t, size_t);
  */
 size_t
 vs_colpos(SCR *sp, recno_t lno, size_t cno)

--- a/vi/vs_smap.c
+++ b/vi/vs_smap.c
@@ -26,20 +26,20 @@ static const char sccsid[] = "$Id: vs_smap.c,v 10.31 2011/02/26 13:56:21 skimo E
 #include "../common/common.h"
 #include "vi.h"
 
-static int	vs_deleteln __P((SCR *, int));
-static int	vs_insertln __P((SCR *, int));
-static int	vs_sm_delete __P((SCR *, recno_t));
-static int	vs_sm_down __P((SCR *, MARK *, recno_t, scroll_t, SMAP *));
-static int	vs_sm_erase __P((SCR *));
-static int	vs_sm_insert __P((SCR *, recno_t));
-static int	vs_sm_reset __P((SCR *, recno_t));
-static int	vs_sm_up __P((SCR *, MARK *, recno_t, scroll_t, SMAP *));
+static int	vs_deleteln(SCR *, int);
+static int	vs_insertln(SCR *, int);
+static int	vs_sm_delete(SCR *, recno_t);
+static int	vs_sm_down(SCR *, MARK *, recno_t, scroll_t, SMAP *);
+static int	vs_sm_erase(SCR *);
+static int	vs_sm_insert(SCR *, recno_t);
+static int	vs_sm_reset(SCR *, recno_t);
+static int	vs_sm_up(SCR *, MARK *, recno_t, scroll_t, SMAP *);
 
 /*
  * vs_change --
  *	Make a change to the screen.
  *
- * PUBLIC: int vs_change __P((SCR *, recno_t, lnop_t));
+ * PUBLIC: int vs_change(SCR *, recno_t, lnop_t);
  */
 int
 vs_change(SCR *sp, recno_t lno, lnop_t op)
@@ -171,7 +171,7 @@ vs_change(SCR *sp, recno_t lno, lnop_t op)
  * slot is already filled in, P_BOTTOM means that the TMAP slot is
  * already filled in, and we just finish up the job.
  *
- * PUBLIC: int vs_sm_fill __P((SCR *, recno_t, pos_t));
+ * PUBLIC: int vs_sm_fill(SCR *, recno_t, pos_t);
  */
 int
 vs_sm_fill(SCR *sp, recno_t lno, pos_t pos)
@@ -512,7 +512,7 @@ vs_sm_reset(SCR *sp, recno_t lno)
  *	Scroll the SMAP up/down count logical lines.  Different
  *	semantics based on the vi command, *sigh*.
  *
- * PUBLIC: int vs_sm_scroll __P((SCR *, MARK *, recno_t, scroll_t));
+ * PUBLIC: int vs_sm_scroll(SCR *, MARK *, recno_t, scroll_t);
  */
 int
 vs_sm_scroll(SCR *sp, MARK *rp, recno_t count, scroll_t scmd)
@@ -745,7 +745,7 @@ vs_sm_up(SCR *sp, MARK *rp, recno_t count, scroll_t scmd, SMAP *smp)
  * vs_sm_1up --
  *	Scroll the SMAP up one.
  *
- * PUBLIC: int vs_sm_1up __P((SCR *));
+ * PUBLIC: int vs_sm_1up(SCR *);
  */
 int
 vs_sm_1up(SCR *sp)
@@ -978,7 +978,7 @@ vs_sm_erase(SCR *sp)
  * vs_sm_1down --
  *	Scroll the SMAP down one.
  *
- * PUBLIC: int vs_sm_1down __P((SCR *));
+ * PUBLIC: int vs_sm_1down(SCR *);
  */
 int
 vs_sm_1down(SCR *sp)
@@ -1042,7 +1042,7 @@ vs_insertln(SCR *sp, int cnt)
  * vs_sm_next --
  *	Fill in the next entry in the SMAP.
  *
- * PUBLIC: int vs_sm_next __P((SCR *, SMAP *, SMAP *));
+ * PUBLIC: int vs_sm_next(SCR *, SMAP *, SMAP *);
  */
 int
 vs_sm_next(SCR *sp, SMAP *p, SMAP *t)
@@ -1070,7 +1070,7 @@ vs_sm_next(SCR *sp, SMAP *p, SMAP *t)
  * vs_sm_prev --
  *	Fill in the previous entry in the SMAP.
  *
- * PUBLIC: int vs_sm_prev __P((SCR *, SMAP *, SMAP *));
+ * PUBLIC: int vs_sm_prev(SCR *, SMAP *, SMAP *);
  */
 int
 vs_sm_prev(SCR *sp, SMAP *p, SMAP *t)
@@ -1095,7 +1095,7 @@ vs_sm_prev(SCR *sp, SMAP *p, SMAP *t)
  * vs_sm_cursor --
  *	Return the SMAP entry referenced by the cursor.
  *
- * PUBLIC: int vs_sm_cursor __P((SCR *, SMAP **));
+ * PUBLIC: int vs_sm_cursor(SCR *, SMAP **);
  */
 int
 vs_sm_cursor(SCR *sp, SMAP **smpp)
@@ -1134,7 +1134,7 @@ vs_sm_cursor(SCR *sp, SMAP **smpp)
  *	(The vi H, M and L commands.)  Here because only the screen routines
  *	know what's really out there.
  *
- * PUBLIC: int vs_sm_position __P((SCR *, MARK *, u_long, pos_t));
+ * PUBLIC: int vs_sm_position(SCR *, MARK *, u_long, pos_t);
  */
 int
 vs_sm_position(SCR *sp, MARK *rp, u_long cnt, pos_t pos)
@@ -1214,7 +1214,7 @@ eof:				msgq(sp, M_BERR,
  *	Return the number of screen lines from an SMAP entry to the
  *	start of some file line, less than a maximum value.
  *
- * PUBLIC: recno_t vs_sm_nlines __P((SCR *, SMAP *, recno_t, size_t));
+ * PUBLIC: recno_t vs_sm_nlines(SCR *, SMAP *, recno_t, size_t);
  */
 recno_t
 vs_sm_nlines(SCR *sp, SMAP *from_sp, recno_t to_lno, size_t max)

--- a/vi/vs_split.c
+++ b/vi/vs_split.c
@@ -29,15 +29,15 @@ static const char sccsid[] = "$Id: vs_split.c,v 10.42 2001/06/25 15:19:38 skimo 
 
 typedef enum { HORIZ_FOLLOW, HORIZ_PRECEDE, VERT_FOLLOW, VERT_PRECEDE } jdir_t;
 
-static SCR	*vs_getbg __P((SCR *, char *));
-static void      vs_insert __P((SCR *sp, GS *gp));
-static int	 vs_join __P((SCR *, SCR **, jdir_t *));
+static SCR	*vs_getbg(SCR *, char *);
+static void      vs_insert(SCR *sp, GS *gp);
+static int	 vs_join(SCR *, SCR **, jdir_t *);
 
 /*
  * vs_split --
  *	Create a new screen, horizontally.
  *
- * PUBLIC: int vs_split __P((SCR *, SCR *, int));
+ * PUBLIC: int vs_split(SCR *, SCR *, int);
  */
 int
 vs_split(
@@ -202,7 +202,7 @@ vs_split(
  * vs_vsplit --
  *	Create a new screen, vertically.
  *
- * PUBLIC: int vs_vsplit __P((SCR *, SCR *));
+ * PUBLIC: int vs_vsplit(SCR *, SCR *);
  */
 int
 vs_vsplit(SCR *sp, SCR *new)
@@ -331,7 +331,7 @@ vs_insert(SCR *sp, GS *gp)
  *	Discard the screen, folding the real-estate into a related screen,
  *	if one exists, and return that screen.
  *
- * PUBLIC: int vs_discard __P((SCR *, SCR **));
+ * PUBLIC: int vs_discard(SCR *, SCR **);
  */
 int
 vs_discard(SCR *sp, SCR **spp)
@@ -608,7 +608,7 @@ vs_join(SCR *sp, SCR **listp, jdir_t *jdirp)
  * vs_fg --
  *	Background the current screen, and foreground a new one.
  *
- * PUBLIC: int vs_fg __P((SCR *, SCR **, CHAR_T *, int));
+ * PUBLIC: int vs_fg(SCR *, SCR **, CHAR_T *, int);
  */
 int
 vs_fg(SCR *sp, SCR **nspp, CHAR_T *name, int newscreen)
@@ -661,7 +661,7 @@ vs_fg(SCR *sp, SCR **nspp, CHAR_T *name, int newscreen)
  * vs_bg --
  *	Background the screen, and switch to the next one.
  *
- * PUBLIC: int vs_bg __P((SCR *));
+ * PUBLIC: int vs_bg(SCR *);
  */
 int
 vs_bg(SCR *sp)
@@ -699,7 +699,7 @@ vs_bg(SCR *sp)
  * vs_swap --
  *	Swap the current screen with a backgrounded one.
  *
- * PUBLIC: int vs_swap __P((SCR *, SCR **, char *));
+ * PUBLIC: int vs_swap(SCR *, SCR **, char *);
  */
 int
 vs_swap(SCR *sp, SCR **nspp, char *name)
@@ -794,7 +794,7 @@ vs_swap(SCR *sp, SCR **nspp, char *name)
  * vs_resize --
  *	Change the absolute size of the current screen.
  *
- * PUBLIC: int vs_resize __P((SCR *, long, adj_t));
+ * PUBLIC: int vs_resize(SCR *, long, adj_t);
  */
 int
 vs_resize(SCR *sp, long int count, adj_t adj)


### PR DESCRIPTION
Reduces the diff to OpenBSD by about 2000 lines.
