### PR TITLE
KNF and ansify.

### DIFF
--- a/catalog/dump.c
+++ b/catalog/dump.c
@@ -35,8 +35,7 @@ static char sccsid[] = "$Id: dump.c,v 8.2 2011/07/14 00:05:25 zy Exp $";
 #include <stdio.h>
 
 static void
-parse(fp)
-	FILE *fp;
+parse(FILE *fp)
 {
 	int ch, s1, s2, s3;
 
@@ -86,9 +85,7 @@ parse(fp)
 }
 
 int
-main(argc, argv)
-	int argc;
-	char *argv[];
+main(int argc, char *argv[])
 {
 	FILE *fp;
 

--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -49,7 +49,7 @@ static void	   term_init(char *, char *);
  *	This is the main loop for the standalone curses editor.
  */
 int
-main(int argc, char **argv)
+main(int argc, char *argv[])
 {
 	static int reenter;
 	CL_PRIVATE *clp;
@@ -337,7 +337,7 @@ sig_init(GS *gp, SCR *sp)
  *	Set a signal handler.
  */
 static int
-setsig(int signo, struct sigaction *oactp, void (*handler) (int))
+setsig(int signo, struct sigaction *oactp, void (*handler)(int))
 {
 	struct sigaction act;
 

--- a/cl/cl_read.c
+++ b/cl/cl_read.c
@@ -143,7 +143,8 @@ read:
  *	Read characters from the input.
  */
 static input_t
-cl_read(SCR *sp, u_int32_t flags, char *bp, size_t blen, int *nrp, struct timeval *tp)
+cl_read(SCR *sp, u_int32_t flags, char *bp, size_t blen, int *nrp,
+    struct timeval *tp)
 {
 	struct termios term1, term2;
 	CL_PRIVATE *clp;

--- a/common/conv.c
+++ b/common/conv.c
@@ -41,32 +41,32 @@ static const char sccsid[] = "$Id: conv.c,v 2.40 2014/02/27 16:25:29 zy Exp $";
 char *
 codeset(void)
 {
-    static char *cs;
+	static char *cs;
 
-    if (cs == NULL)
-	cs = nl_langinfo(CODESET);
+	if (cs == NULL)
+		cs = nl_langinfo(CODESET);
 
-    return cs;
+	return cs;
 }
 
 #ifdef USE_WIDECHAR
 static int 
-raw2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw,
-	size_t *tolen, CHAR_T **dst)
+raw2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, size_t *tolen,
+    CHAR_T **dst)
 {
-    int i;
-    CHAR_T **tostr = &cw->bp1.wc;
-    size_t  *blen = &cw->blen1;
+	int i;
+	CHAR_T **tostr = &cw->bp1.wc;
+	size_t  *blen = &cw->blen1;
 
-    BINC_RETW(NULL, *tostr, *blen, len);
+	BINC_RETW(NULL, *tostr, *blen, len);
 
-    *tolen = len;
-    for (i = 0; i < len; ++i)
-	(*tostr)[i] = (u_char) str[i];
+	*tolen = len;
+	for (i = 0; i < len; ++i)
+		(*tostr)[i] = (u_char) str[i];
 
-    *dst = cw->bp1.wc;
+	*dst = cw->bp1.wc;
 
-    return 0;
+	return 0;
 }
 
 #define CONV_BUFFER_SIZE    512
@@ -76,26 +76,26 @@ raw2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw,
  */
 #ifdef USE_ICONV
 #define CONVERT(str, left, src, len)					\
-    do {								\
-	size_t outleft;							\
-	char *bp = buffer;						\
-	outleft = CONV_BUFFER_SIZE;					\
-	errno = 0;							\
-	if (iconv(id, (iconv_src_t)&str, &left, &bp, &outleft) == -1 &&	\
-		errno != E2BIG)						\
-	    goto err;							\
-	if ((len = CONV_BUFFER_SIZE - outleft) == 0) {			\
-	    error = -left;						\
-	    goto err;							\
-	}								\
-	src = buffer;							\
-    } while (0)
+	do {								\
+		size_t outleft;						\
+		char *bp = buffer;					\
+		outleft = CONV_BUFFER_SIZE;				\
+		errno = 0;						\
+		if (iconv(id, (iconv_src_t)&str, &left, &bp, &outleft)	\
+		    == -1 && errno != E2BIG)				\
+			goto err;					\
+		if ((len = CONV_BUFFER_SIZE - outleft) == 0) {		\
+			error = -left;					\
+			goto err;					\
+		}							\
+		src = buffer;						\
+	} while (0)
 
 #define IC_RESET()							\
-    do {								\
-	if (id != (iconv_t)-1)						\
-	    iconv(id, NULL, NULL, NULL, NULL);				\
-    } while(0)
+	do {								\
+		if (id != (iconv_t)-1)					\
+			iconv(id, NULL, NULL, NULL, NULL);		\
+	} while(0)
 #else
 #define CONVERT(str, left, src, len)
 #define IC_RESET()
@@ -103,114 +103,116 @@ raw2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw,
 
 static int 
 default_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, 
-		size_t *tolen, CHAR_T **dst, iconv_t id)
+    size_t *tolen, CHAR_T **dst, iconv_t id)
 {
-    size_t i = 0, j;
-    CHAR_T **tostr = &cw->bp1.wc;
-    size_t  *blen = &cw->blen1;
-    mbstate_t mbs;
-    size_t   n;
-    ssize_t  nlen = len;
-    char *src = (char *)str;
+	size_t i = 0, j;
+	CHAR_T **tostr = &cw->bp1.wc;
+	size_t *blen = &cw->blen1;
+	mbstate_t mbs;
+	size_t n;
+	ssize_t nlen = len;
+	char *src = (char *)str;
 #ifdef USE_ICONV
-    char	buffer[CONV_BUFFER_SIZE];
+	char buffer[CONV_BUFFER_SIZE];
 #endif
-    size_t	left = len;
-    int		error = 1;
+	size_t left = len;
+	int error = 1;
 
-    BZERO(&mbs, 1);
-    BINC_RETW(NULL, *tostr, *blen, nlen);
+	BZERO(&mbs, 1);
+	BINC_RETW(NULL, *tostr, *blen, nlen);
 
 #ifdef USE_ICONV
-    if (id != (iconv_t)-1)
-	CONVERT(str, left, src, len);
+	if (id != (iconv_t)-1)
+		CONVERT(str, left, src, len);
 #endif
 
-    for (i = 0, j = 0; j < len; ) {
-	n = mbrtowc((*tostr)+i, src+j, len-j, &mbs);
-	/* NULL character converted */
-	if (n == -2) error = -(len-j);
-	if (n == -1 || n == -2) goto err;
-	if (n == 0) n = 1;
-	j += n;
-	if (++i >= *blen) {
-	    nlen += 256;
-	    BINC_RETW(NULL, *tostr, *blen, nlen);
+	for (i = 0, j = 0; j < len; ) {
+		n = mbrtowc((*tostr)+i, src+j, len-j, &mbs);
+		/* NULL character converted */
+		if (n == -2)
+			error = -(len-j);
+		if (n == -1 || n == -2)
+			goto err;
+		if (n == 0)
+			n = 1;
+		j += n;
+		if (++i >= *blen) {
+			nlen += 256;
+			BINC_RETW(NULL, *tostr, *blen, nlen);
+		}
+		if (id != (iconv_t)-1 && j == len && left) {
+			CONVERT(str, left, src, len);
+			j = 0;
+		}
 	}
-	if (id != (iconv_t)-1 && j == len && left) {
-	    CONVERT(str, left, src, len);
-	    j = 0;
-	}
-    }
 
-    error = 0;
+	error = 0;
 err:
-    *tolen = i;
-    *dst = cw->bp1.wc;
-    IC_RESET();
+	*tolen = i;
+	*dst = cw->bp1.wc;
+	IC_RESET();
 
-    return error;
+	return error;
 }
 
 static int 
-fe_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, 
-	    size_t *tolen, CHAR_T **dst)
+fe_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, size_t *tolen,
+    CHAR_T **dst)
 {
-    return default_char2int(sp, str, len, cw, tolen, dst,
-	sp->conv.id[IC_FE_CHAR2INT]);
+	return default_char2int(sp, str, len, cw, tolen, dst,
+	    sp->conv.id[IC_FE_CHAR2INT]);
 }
 
 static int 
-ie_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, 
-	    size_t *tolen, CHAR_T **dst)
+ie_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, size_t *tolen,
+    CHAR_T **dst)
 {
-    return default_char2int(sp, str, len, cw, tolen, dst,
-	sp->conv.id[IC_IE_CHAR2INT]);
+	return default_char2int(sp, str, len, cw, tolen, dst,
+	    sp->conv.id[IC_IE_CHAR2INT]);
 }
 
 static int 
-cs_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, 
-	    size_t *tolen, CHAR_T **dst)
+cs_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw, size_t *tolen,
+    CHAR_T **dst)
 {
-    return default_char2int(sp, str, len, cw, tolen, dst,
-	(iconv_t)-1);
+	return default_char2int(sp, str, len, cw, tolen, dst, (iconv_t)-1);
 }
 
 static int 
-int2raw(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw,
-	size_t *tolen, char **dst)
+int2raw(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw, size_t *tolen,
+    char **dst)
 {
-    int i;
-    char **tostr = &cw->bp1.c;
-    size_t  *blen = &cw->blen1;
+	int i;
+	char **tostr = &cw->bp1.c;
+	size_t  *blen = &cw->blen1;
 
-    BINC_RETC(NULL, *tostr, *blen, len);
+	BINC_RETC(NULL, *tostr, *blen, len);
 
-    *tolen = len;
-    for (i = 0; i < len; ++i)
-	(*tostr)[i] = str[i];
+	*tolen = len;
+	for (i = 0; i < len; ++i)
+		(*tostr)[i] = str[i];
 
-    *dst = cw->bp1.c;
+	*dst = cw->bp1.c;
 
-    return 0;
+	return 0;
 }
 
 static int 
 default_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw, 
-		size_t *tolen, char **pdst, iconv_t id)
+    size_t *tolen, char **pdst, iconv_t id)
 {
-    size_t i, j, offset = 0;
-    char **tostr = &cw->bp1.c;
-    size_t  *blen = &cw->blen1;
-    mbstate_t mbs;
-    size_t n;
-    ssize_t  nlen = len + MB_CUR_MAX;
-    char *dst;
-    size_t buflen;
+	size_t i, j, offset = 0;
+	char **tostr = &cw->bp1.c;
+	size_t *blen = &cw->blen1;
+	mbstate_t mbs;
+	size_t n;
+	ssize_t  nlen = len + MB_CUR_MAX;
+	char *dst;
+	size_t buflen;
 #ifdef USE_ICONV
-    char	buffer[CONV_BUFFER_SIZE];
+	char buffer[CONV_BUFFER_SIZE];
 #endif
-    int		error = 1;
+	int error = 1;
 
 /* convert first len bytes of buffer and append it to cw->bp
  * len is adjusted => 0
@@ -219,87 +221,90 @@ default_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw,
  */
 #ifdef USE_ICONV
 #define CONVERT2(_buffer, lenp, cw, offset)				\
-    do {								\
-	char *bp = _buffer;						\
-	int ret;							\
 	do {								\
-	    size_t outleft = cw->blen1 - offset;			\
-	    char *obp = cw->bp1.c + offset;				\
-	    if (cw->blen1 < offset + MB_CUR_MAX) {			\
-		nlen += 256;						\
-		BINC_RETC(NULL, cw->bp1.c, cw->blen1, nlen);		\
-	    }								\
-	    errno = 0;							\
-	    ret = iconv(id, (iconv_src_t)&bp, lenp, &obp, &outleft);	\
-	    if (ret == -1 && errno != E2BIG)				\
-		goto err;						\
-	    offset = cw->blen1 - outleft;				\
-	} while (ret != 0); 						\
-    } while (0)
+		char *bp = _buffer;					\
+		int ret;						\
+		do {							\
+			size_t outleft = cw->blen1 - offset;		\
+			char *obp = cw->bp1.c + offset;			\
+			if (cw->blen1 < offset + MB_CUR_MAX) {		\
+				nlen += 256;				\
+				BINC_RETC(NULL, cw->bp1.c, cw->blen1,	\
+				    nlen);				\
+			}						\
+			errno = 0;					\
+			ret = iconv(id, (iconv_src_t)&bp, lenp, &obp,	\
+			    &outleft);					\
+			if (ret == -1 && errno != E2BIG)		\
+				goto err;				\
+			offset = cw->blen1 - outleft;			\
+		} while (ret != 0); 					\
+	} while (0)
 #else
 #define CONVERT2(_buffer, lenp, cw, offset)
 #endif
 
 
-    BZERO(&mbs, 1);
-    BINC_RETC(NULL, *tostr, *blen, nlen);
-    dst = *tostr; buflen = *blen;
+	BZERO(&mbs, 1);
+	BINC_RETC(NULL, *tostr, *blen, nlen);
+	dst = *tostr; buflen = *blen;
 
 #ifdef USE_ICONV
-    if (id != (iconv_t)-1) {
-	dst = buffer; buflen = CONV_BUFFER_SIZE;
-    }
+	if (id != (iconv_t)-1) {
+		dst = buffer; buflen = CONV_BUFFER_SIZE;
+	}
 #endif
 
-    for (i = 0, j = 0; i < len; ++i) {
-	n = wcrtomb(dst+j, str[i], &mbs);
-	if (n == -1) goto err;
-	j += n;
-	if (buflen < j + MB_CUR_MAX) {
-	    if (id != (iconv_t)-1) {
-		CONVERT2(buffer, &j, cw, offset);
-	    } else {
-		nlen += 256;
-		BINC_RETC(NULL, *tostr, *blen, nlen);
-		dst = *tostr; buflen = *blen;
-	    }
+	for (i = 0, j = 0; i < len; ++i) {
+		n = wcrtomb(dst+j, str[i], &mbs);
+		if (n == -1)
+			goto err;
+		j += n;
+		if (buflen < j + MB_CUR_MAX) {
+			if (id != (iconv_t)-1) {
+				CONVERT2(buffer, &j, cw, offset);
+			} else {
+				nlen += 256;
+				BINC_RETC(NULL, *tostr, *blen, nlen);
+				dst = *tostr; buflen = *blen;
+			}
+		}
 	}
-    }
 
-    n = wcrtomb(dst+j, L'\0', &mbs);
-    j += n - 1;				/* don't count NUL at the end */
-    *tolen = j;
-
-    if (id != (iconv_t)-1) {
-	CONVERT2(buffer, &j, cw, offset);
-	CONVERT2(NULL, NULL, cw, offset);  /* back to the initial state */
-	*tolen = offset;
-    }
-
-    error = 0;
-err:
-    if (error)
+	n = wcrtomb(dst+j, L'\0', &mbs);
+	j += n - 1;				/* don't count NUL at the end */
 	*tolen = j;
-    *pdst = cw->bp1.c;
-    IC_RESET();
 
-    return error;
+	if (id != (iconv_t)-1) {
+		CONVERT2(buffer, &j, cw, offset);
+		/* back to the initial state */
+		CONVERT2(NULL, NULL, cw, offset);
+		*tolen = offset;
+	}
+
+	error = 0;
+err:
+	if (error)
+		*tolen = j;
+	*pdst = cw->bp1.c;
+	IC_RESET();
+
+	return error;
 }
 
 static int 
 fe_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw, 
-	    size_t *tolen, char **dst)
+    size_t *tolen, char **dst)
 {
-    return default_int2char(sp, str, len, cw, tolen, dst,
-	sp->conv.id[IC_FE_INT2CHAR]);
+	return default_int2char(sp, str, len, cw, tolen, dst,
+		sp->conv.id[IC_FE_INT2CHAR]);
 }
 
 static int 
 cs_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw, 
-	    size_t *tolen, char **dst)
+    size_t *tolen, char **dst)
 {
-    return default_int2char(sp, str, len, cw, tolen, dst,
-	(iconv_t)-1);
+	return default_int2char(sp, str, len, cw, tolen, dst, (iconv_t)-1);
 }
 
 #endif
@@ -313,53 +318,53 @@ cs_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw,
 void
 conv_init(SCR *orig, SCR *sp)
 {
-    int i;
+	int i;
 
-    if (orig == NULL)
-	setlocale(LC_ALL, "");
-    if (orig != NULL)
-	BCOPY(&orig->conv, &sp->conv, 1);
+	if (orig == NULL)
+		setlocale(LC_ALL, "");
+	if (orig != NULL)
+		BCOPY(&orig->conv, &sp->conv, 1);
 #ifdef USE_WIDECHAR
-    else {
-	char *ctype = setlocale(LC_CTYPE, NULL);
+	else {
+		char *ctype = setlocale(LC_CTYPE, NULL);
 
-	/*
-	 * XXX
-	 * This hack fixes the libncursesw issue on FreeBSD.
-	 */
-	if (!strcmp(ctype, "ko_KR.CP949"))
-	    setlocale(LC_CTYPE, "ko_KR.eucKR");
-	else if (!strcmp(ctype, "zh_CN.GB2312"))
-	    setlocale(LC_CTYPE, "zh_CN.eucCN");
-	else if (!strcmp(ctype, "zh_CN.GBK"))
-	    setlocale(LC_CTYPE, "zh_CN.GB18030");
+		/*
+		 * XXX
+		 * This hack fixes the libncursesw issue on FreeBSD.
+		 */
+		if (!strcmp(ctype, "ko_KR.CP949"))
+			setlocale(LC_CTYPE, "ko_KR.eucKR");
+		else if (!strcmp(ctype, "zh_CN.GB2312"))
+			setlocale(LC_CTYPE, "zh_CN.eucCN");
+		else if (!strcmp(ctype, "zh_CN.GBK"))
+			setlocale(LC_CTYPE, "zh_CN.GB18030");
 
-	/*
-	 * Switch to 8bit mode if locale is C;
-	 * LC_CTYPE should be reseted to C if unmatched.
-	 */
-	if (!strcmp(ctype, "C") || !strcmp(ctype, "POSIX")) {
-	    sp->conv.sys2int = sp->conv.file2int = raw2int;
-	    sp->conv.int2sys = sp->conv.int2file = int2raw;
-	    sp->conv.input2int = raw2int;
-	} else {
-	    sp->conv.sys2int = cs_char2int;
-	    sp->conv.int2sys = cs_int2char;
-	    sp->conv.file2int = fe_char2int;
-	    sp->conv.int2file = fe_int2char;
-	    sp->conv.input2int = ie_char2int;
+		/*
+		 * Switch to 8bit mode if locale is C;
+		 * LC_CTYPE should be reseted to C if unmatched.
+		 */
+		if (!strcmp(ctype, "C") || !strcmp(ctype, "POSIX")) {
+			sp->conv.sys2int = sp->conv.file2int = raw2int;
+			sp->conv.int2sys = sp->conv.int2file = int2raw;
+			sp->conv.input2int = raw2int;
+		} else {
+			sp->conv.sys2int = cs_char2int;
+			sp->conv.int2sys = cs_int2char;
+			sp->conv.file2int = fe_char2int;
+			sp->conv.int2file = fe_int2char;
+			sp->conv.input2int = ie_char2int;
+		}
+#ifdef USE_ICONV
+		o_set(sp, O_INPUTENCODING, OS_STRDUP, codeset(), 0);
+#endif
 	}
-#ifdef USE_ICONV
-	o_set(sp, O_INPUTENCODING, OS_STRDUP, codeset(), 0);
-#endif
-    }
 #endif
 
-    /* iconv descriptors must be distinct to screens. */
-    for (i = 0; i <= IC_IE_TO_UTF16; ++i)
-	sp->conv.id[i] = (iconv_t)-1;
+	/* iconv descriptors must be distinct to screens. */
+	for (i = 0; i <= IC_IE_TO_UTF16; ++i)
+		sp->conv.id[i] = (iconv_t)-1;
 #ifdef USE_ICONV
-    conv_enc(sp, O_INPUTENCODING, 0);
+	conv_enc(sp, O_INPUTENCODING, 0);
 #endif
 }
 
@@ -373,73 +378,76 @@ int
 conv_enc(SCR *sp, int option, char *enc)
 {
 #if defined(USE_WIDECHAR) && defined(USE_ICONV)
-    iconv_t *c2w, *w2c;
-    iconv_t id_c2w, id_w2c;
+	iconv_t *c2w, *w2c;
+	iconv_t id_c2w, id_w2c;
 
-    switch (option) {
-    case O_FILEENCODING:
-	c2w = sp->conv.id + IC_FE_CHAR2INT;
-	w2c = sp->conv.id + IC_FE_INT2CHAR;
-	if (!enc) enc = O_STR(sp, O_FILEENCODING);
+	switch (option) {
+	case O_FILEENCODING:
+		c2w = sp->conv.id + IC_FE_CHAR2INT;
+		w2c = sp->conv.id + IC_FE_INT2CHAR;
+		if (!enc)
+			enc = O_STR(sp, O_FILEENCODING);
 
-	if (strcasecmp(codeset(), enc)) {
-	    if ((id_c2w = iconv_open(codeset(), enc)) == (iconv_t)-1)
-		goto err;
-	    if ((id_w2c = iconv_open(enc, codeset())) == (iconv_t)-1)
-		goto err;
-	} else {
-	    id_c2w = (iconv_t)-1;
-	    id_w2c = (iconv_t)-1;
+		if (strcasecmp(codeset(), enc)) {
+			if ((id_c2w = iconv_open(codeset(), enc)) ==
+			    (iconv_t)-1)
+				goto err;
+			if ((id_w2c = iconv_open(enc, codeset())) ==
+			    (iconv_t)-1)
+				goto err;
+		} else {
+			id_c2w = (iconv_t)-1;
+			id_w2c = (iconv_t)-1;
+		}
+
+		break;
+
+	case O_INPUTENCODING:
+		c2w = sp->conv.id + IC_IE_CHAR2INT;
+		w2c = sp->conv.id + IC_IE_TO_UTF16;
+		if (!enc)
+			enc = O_STR(sp, O_INPUTENCODING);
+
+		if (strcasecmp(codeset(), enc)) {
+			if ((id_c2w = iconv_open(codeset(), enc)) ==
+			    (iconv_t)-1)
+				goto err;
+		} else
+			id_c2w = (iconv_t)-1;
+
+		/* UTF-16 can not be locale and can not be inputed. */
+		if ((id_w2c = iconv_open("utf-16be", enc)) == (iconv_t)-1)
+			goto err;
+
+		break;
+
+	default:
+		abort();
 	}
 
-	break;
+	if (*c2w != (iconv_t)-1)
+		iconv_close(*c2w);
+	if (*w2c != (iconv_t)-1)
+		iconv_close(*w2c);
 
-    case O_INPUTENCODING:
-	c2w = sp->conv.id + IC_IE_CHAR2INT;
-	w2c = sp->conv.id + IC_IE_TO_UTF16;
-	if (!enc) enc = O_STR(sp, O_INPUTENCODING);
+	*c2w = id_c2w;
+	*w2c = id_w2c;
 
-	if (strcasecmp(codeset(), enc)) {
-	    if ((id_c2w = iconv_open(codeset(), enc)) == (iconv_t)-1)
-		goto err;
-	} else
-	    id_c2w = (iconv_t)-1;
+	F_CLR(sp, SC_CONV_ERROR);
+	F_SET(sp, SC_SCR_REFORMAT);
 
-	/* UTF-16 can not be locale and can not be inputed. */
-	if ((id_w2c = iconv_open("utf-16be", enc)) == (iconv_t)-1)
-	    goto err;
-
-	break;
-
-    default:
-	abort();
-    }
-
-    if (*c2w != (iconv_t)-1)
-	iconv_close(*c2w);
-    if (*w2c != (iconv_t)-1)
-	iconv_close(*w2c);
-
-    *c2w = id_c2w;
-    *w2c = id_w2c;
-
-    F_CLR(sp, SC_CONV_ERROR);
-    F_SET(sp, SC_SCR_REFORMAT);
-
-    return 0;
+	return 0;
 err:
 #endif
-    switch (option) {
-    case O_FILEENCODING:
-	msgq(sp, M_ERR,
-	    "321|File encoding conversion not supported");
-	break;
-    case O_INPUTENCODING:
-	msgq(sp, M_ERR,
-	    "322|Input encoding conversion not supported");
-	break;
-    }
-    return 1;
+	switch (option) {
+	case O_FILEENCODING:
+		msgq(sp, M_ERR, "321|File encoding conversion not supported");
+		break;
+	case O_INPUTENCODING:
+		msgq(sp, M_ERR, "322|Input encoding conversion not supported");
+		break;
+	}
+	return 1;
 }
 
 /*
@@ -452,11 +460,11 @@ void
 conv_end(SCR *sp)
 {
 #if defined(USE_WIDECHAR) && defined(USE_ICONV)
-    int i;
-    for (i = 0; i <= IC_IE_TO_UTF16; ++i)
-	if (sp->conv.id[i] != (iconv_t)-1)
-	    iconv_close(sp->conv.id[i]);
+	int i;
+	for (i = 0; i <= IC_IE_TO_UTF16; ++i)
+		if (sp->conv.id[i] != (iconv_t)-1)
+			iconv_close(sp->conv.id[i]);
 	if (sp->cw.bp1.c != NULL)
-	    free(sp->cw.bp1.c);
+		free(sp->cw.bp1.c);
 #endif
 }

--- a/common/cut.c
+++ b/common/cut.c
@@ -64,12 +64,7 @@ static void	cb_rotate(SCR *);
  * PUBLIC: int cut(SCR *, CHAR_T *, MARK *, MARK *, int);
  */
 int
-cut(
-	SCR *sp,
-	CHAR_T *namep,
-	MARK *fm,
-	MARK *tm,
-	int flags)
+cut(SCR *sp, CHAR_T *namep, MARK *fm, MARK *tm, int flags)
 {
 	CB *cbp;
 	CHAR_T name = '\0';
@@ -225,12 +220,7 @@ cb_rotate(SCR *sp)
  * PUBLIC: int cut_line(SCR *, recno_t, size_t, size_t, CB *);
  */
 int
-cut_line(
-	SCR *sp,
-	recno_t lno,
-	size_t fcno,
-	size_t clen,
-	CB *cbp)
+cut_line(SCR *sp, recno_t lno, size_t fcno, size_t clen, CB *cbp)
 {
 	TEXT *tp;
 	size_t len;
@@ -294,11 +284,7 @@ cut_close(GS *gp)
  * PUBLIC: TEXT *text_init(SCR *, const CHAR_T *, size_t, size_t);
  */
 TEXT *
-text_init(
-	SCR *sp,
-	const CHAR_T *p,
-	size_t len,
-	size_t total_len)
+text_init(SCR *sp, const CHAR_T *p, size_t len, size_t total_len)
 {
 	TEXT *tp;
 

--- a/common/delete.c
+++ b/common/delete.c
@@ -33,11 +33,7 @@ static const char sccsid[] = "$Id: delete.c,v 10.18 2012/02/11 15:52:33 zy Exp $
  * PUBLIC: int del(SCR *, MARK *, MARK *, int);
  */
 int
-del(
-	SCR *sp,
-	MARK *fm,
-	MARK *tm,
-	int lmode)
+del(SCR *sp, MARK *fm, MARK *tm, int lmode)
 {
 	recno_t lno;
 	size_t blen, len, nlen, tlen;

--- a/common/exf.c
+++ b/common/exf.c
@@ -59,9 +59,7 @@ static int	file_spath(SCR *, FREF *, struct stat *, int *);
  * PUBLIC: FREF *file_add(SCR *, char *);
  */
 FREF *
-file_add(
-	SCR *sp,
-	char *name)
+file_add(SCR *sp, char *name)
 {
 	GS *gp;
 	FREF *frp, *tfrp;
@@ -121,11 +119,7 @@ file_add(
  * PUBLIC: int file_init(SCR *, FREF *, char *, int);
  */
 int
-file_init(
-	SCR *sp,
-	FREF *frp,
-	char *rcv_name,
-	int flags)
+file_init(SCR *sp, FREF *frp, char *rcv_name, int flags)
 {
 	EXF *ep;
 	RECNOINFO oinfo = { 0 };
@@ -444,11 +438,7 @@ oerr:	if (F_ISSET(ep, F_RCV_ON))
  *	try and open.
  */
 static int
-file_spath(
-	SCR *sp,
-	FREF *frp,
-	struct stat *sbp,
-	int *existsp)
+file_spath(SCR *sp, FREF *frp, struct stat *sbp, int *existsp)
 {
 	int savech;
 	size_t len;
@@ -628,10 +618,7 @@ file_cinit(SCR *sp)
  * PUBLIC: int file_end(SCR *, EXF *, int);
  */
 int
-file_end(
-	SCR *sp,
-	EXF *ep,
-	int force)
+file_end(SCR *sp, EXF *ep, int force)
 {
 	FREF *frp;
 
@@ -740,12 +727,7 @@ file_end(
  * PUBLIC: int file_write(SCR *, MARK *, MARK *, char *, int);
  */
 int
-file_write(
-	SCR *sp,
-	MARK *fm,
-	MARK *tm,
-	char *name,
-	int flags)
+file_write(SCR *sp, MARK *fm, MARK *tm, char *name, int flags)
 {
 	enum { NEWFILE, OLDFILE } mtype;
 	struct stat sb;
@@ -1015,10 +997,7 @@ success_open:
  * recreate the file.  So, let's not risk it.
  */
 static int
-file_backup(
-	SCR *sp,
-	char *name,
-	char *bname)
+file_backup(SCR *sp, char *name, char *bname)
 {
 	struct dirent *dp;
 	struct stat sb;
@@ -1305,10 +1284,7 @@ file_comment(SCR *sp)
  * PUBLIC: int file_m1(SCR *, int, int);
  */
 int
-file_m1(
-	SCR *sp,
-	int force,
-	int flags)
+file_m1(SCR *sp, int force, int flags)
 {
 	EXF *ep;
 
@@ -1346,9 +1322,7 @@ file_m1(
  * PUBLIC: int file_m2(SCR *, int);
  */
 int
-file_m2(
-	SCR *sp,
-	int force)
+file_m2(SCR *sp, int force)
 {
 	EXF *ep;
 
@@ -1378,9 +1352,7 @@ file_m2(
  * PUBLIC: int file_m3(SCR *, int);
  */
 int
-file_m3(
-	SCR *sp,
-	int force)
+file_m3(SCR *sp, int force)
 {
 	EXF *ep;
 
@@ -1414,9 +1386,7 @@ file_m3(
  * PUBLIC: int file_aw(SCR *, int);
  */
 int
-file_aw(
-	SCR *sp,
-	int flags)
+file_aw(SCR *sp, int flags)
 {
 	if (!F_ISSET(sp->ep, F_MODIFIED))
 		return (0);
@@ -1475,9 +1445,7 @@ file_aw(
  * PUBLIC: void set_alt_name(SCR *, char *);
  */
 void
-set_alt_name(
-	SCR *sp,
-	char *name)
+set_alt_name(SCR *sp, char *name)
 {
 	if (sp->alt_name != NULL)
 		free(sp->alt_name);
@@ -1494,11 +1462,7 @@ set_alt_name(
  * PUBLIC: lockr_t file_lock(SCR *, char *, int, int);
  */
 lockr_t
-file_lock(
-	SCR *sp,
-	char *name,
-	int fd,
-	int iswrite)
+file_lock(SCR *sp, char *name, int fd, int iswrite)
 {
 	if (!O_ISSET(sp, O_LOCKFILES))
 		return (LOCK_SUCCESS);

--- a/common/key.c
+++ b/common/key.c
@@ -145,10 +145,7 @@ v_key_init(SCR *sp)
  * in the table, so we check for that first.
  */
 static void
-v_keyval(
-	SCR *sp,
-	int val,
-	scr_keyval_t name)
+v_keyval(SCR *sp, int val, scr_keyval_t name)
 {
 	KEYLIST *kp;
 	CHAR_T ch;
@@ -206,9 +203,7 @@ v_key_ilookup(SCR *sp)
  * PUBLIC: size_t v_key_len(SCR *, ARG_CHAR_T);
  */
 size_t
-v_key_len(
-	SCR *sp,
-	ARG_CHAR_T ch)
+v_key_len(SCR *sp, ARG_CHAR_T ch)
 {
 	(void)v_key_name(sp, ch);
 	return (sp->clen);
@@ -222,9 +217,7 @@ v_key_len(
  * PUBLIC: char *v_key_name(SCR *, ARG_CHAR_T);
  */
 char *
-v_key_name(
-	SCR *sp,
-	ARG_CHAR_T ach)
+v_key_name(SCR *sp, ARG_CHAR_T ach)
 {
 	static const char hexdigit[] = "0123456789abcdef";
 	static const char octdigit[] = "01234567";
@@ -330,9 +323,7 @@ done:	sp->cname[sp->clen = len] = '\0';
  * PUBLIC: e_key_t v_key_val(SCR *, ARG_CHAR_T);
  */
 e_key_t
-v_key_val(
-	SCR *sp,
-	ARG_CHAR_T ch)
+v_key_val(SCR *sp, ARG_CHAR_T ch)
 {
 	KEYLIST k, *kp;
 
@@ -354,12 +345,7 @@ v_key_val(
  * PUBLIC: int v_event_push(SCR *, EVENT *, CHAR_T *, size_t, u_int);
  */
 int
-v_event_push(
-	SCR *sp,
-	EVENT *p_evp,			/* Push event. */
-	CHAR_T *p_s,			/* Push characters. */
-	size_t nitems,			/* Number of items to push. */
-	u_int flags)			/* CH_* flags. */
+v_event_push(SCR *sp, EVENT *p_evp, CHAR_T *p_s, size_t nitems, u_int flags)
 {
 	EVENT *evp;
 	GS *gp;
@@ -408,9 +394,7 @@ copy:	gp->i_cnt += nitems;
  *	Append events onto the tail of the buffer.
  */
 static int
-v_event_append(
-	SCR *sp,
-	EVENT *argp)
+v_event_append(SCR *sp, EVENT *argp)
 {
 	CHAR_T *s;			/* Characters. */
 	EVENT *evp;
@@ -535,11 +519,7 @@ v_event_append(
  * PUBLIC: int v_event_get(SCR *, EVENT *, int, u_int32_t);
  */
 int
-v_event_get(
-	SCR *sp,
-	EVENT *argp,
-	int timeout,
-	u_int32_t flags)
+v_event_get(SCR *sp, EVENT *argp, int timeout, u_int32_t flags)
 {
 	EVENT *evp, ev;
 	GS *gp;
@@ -754,9 +734,7 @@ not_digit:	argp->e_c = CH_NOT_DIGIT;
  *	Walk the screen lists, sync'ing files to their backup copies.
  */
 static void
-v_sync(
-	SCR *sp,
-	int flags)
+v_sync(SCR *sp, int flags)
 {
 	GS *gp;
 
@@ -774,9 +752,7 @@ v_sync(
  * PUBLIC: void v_event_err(SCR *, EVENT *);
  */
 void
-v_event_err(
-	SCR *sp,
-	EVENT *evp)
+v_event_err(SCR *sp, EVENT *evp)
 {
 	switch (evp->e_event) {
 	case E_CHARACTER:
@@ -824,9 +800,7 @@ v_event_err(
  * PUBLIC: int v_event_flush(SCR *, u_int);
  */
 int
-v_event_flush(
-	SCR *sp,
-	u_int flags)
+v_event_flush(SCR *sp, u_int flags)
 {
 	GS *gp;
 	int rval;
@@ -842,9 +816,7 @@ v_event_flush(
  *	Grow the terminal queue.
  */
 static int
-v_event_grow(
-	SCR *sp,
-	int add)
+v_event_grow(SCR *sp, int add)
 {
 	GS *gp;
 	size_t new_nelem, olen;
@@ -862,9 +834,7 @@ v_event_grow(
  *	Compare two keys for sorting.
  */
 static int
-v_key_cmp(
-	const void *ap,
-	const void *bp)
+v_key_cmp(const void *ap, const void *bp)
 {
 	return (((KEYLIST *)ap)->ch - ((KEYLIST *)bp)->ch);
 }

--- a/common/line.c
+++ b/common/line.c
@@ -35,12 +35,7 @@ static int scr_update(SCR *, recno_t, lnop_t, int);
  * PUBLIC: int db_eget(SCR *, recno_t, CHAR_T **, size_t *, int *);
  */
 int
-db_eget(
-	SCR *sp,
-	recno_t lno,				/* Line number. */
-	CHAR_T **pp,				/* Pointer store. */
-	size_t *lenp,				/* Length store. */
-	int *isemptyp)
+db_eget(SCR *sp, recno_t lno, CHAR_T **pp, size_t *lenp, int *isemptyp)
 {
 	recno_t l1;
 
@@ -79,12 +74,7 @@ db_eget(
  * PUBLIC: int db_get(SCR *, recno_t, u_int32_t, CHAR_T **, size_t *);
  */
 int
-db_get(
-	SCR *sp,
-	recno_t lno,				/* Line number. */
-	u_int32_t flags,
-	CHAR_T **pp,				/* Pointer store. */
-	size_t *lenp)				/* Length store. */
+db_get(SCR *sp, recno_t lno, u_int32_t flags, CHAR_T **pp, size_t *lenp)
 {
 	DBT data, key;
 	EXF *ep;
@@ -210,9 +200,7 @@ err3:		if (lenp != NULL)
  * PUBLIC: int db_delete(SCR *, recno_t);
  */
 int
-db_delete(
-	SCR *sp,
-	recno_t lno)
+db_delete(SCR *sp, recno_t lno)
 {
 	DBT key;
 	EXF *ep;
@@ -268,12 +256,7 @@ db_delete(
  * PUBLIC: int db_append(SCR *, int, recno_t, CHAR_T *, size_t);
  */
 int
-db_append(
-	SCR *sp,
-	int update,
-	recno_t lno,
-	CHAR_T *p,
-	size_t len)
+db_append(SCR *sp, int update, recno_t lno, CHAR_T *p, size_t len)
 {
 	DBT data, key;
 	EXF *ep;
@@ -346,11 +329,7 @@ db_append(
  * PUBLIC: int db_insert(SCR *, recno_t, CHAR_T *, size_t);
  */
 int
-db_insert(
-	SCR *sp,
-	recno_t lno,
-	CHAR_T *p,
-	size_t len)
+db_insert(SCR *sp, recno_t lno, CHAR_T *p, size_t len)
 {
 	DBT data, key;
 	EXF *ep;
@@ -415,11 +394,7 @@ db_insert(
  * PUBLIC: int db_set(SCR *, recno_t, CHAR_T *, size_t);
  */
 int
-db_set(
-	SCR *sp,
-	recno_t lno,
-	CHAR_T *p,
-	size_t len)
+db_set(SCR *sp, recno_t lno, CHAR_T *p, size_t len)
 {
 	DBT data, key;
 	EXF *ep;
@@ -477,9 +452,7 @@ db_set(
  * PUBLIC: int db_exist(SCR *, recno_t);
  */
 int
-db_exist(
-	SCR *sp,
-	recno_t lno)
+db_exist(SCR *sp, recno_t lno)
 {
 	EXF *ep;
 
@@ -512,9 +485,7 @@ db_exist(
  * PUBLIC: int db_last(SCR *, recno_t *);
  */
 int
-db_last(
-	SCR *sp,
-	recno_t *lnop)
+db_last(SCR *sp, recno_t *lnop)
 {
 	DBT data, key;
 	EXF *ep;
@@ -586,11 +557,7 @@ alloc_err:
  * PUBLIC: int db_rget(SCR *, recno_t, char **, size_t *);
  */
 int
-db_rget(
-	SCR *sp,
-	recno_t lno,				/* Line number. */
-	char **pp,				/* Pointer store. */
-	size_t *lenp)				/* Length store. */
+db_rget(SCR *sp, recno_t lno, char **pp, size_t *lenp)
 {
 	DBT data, key;
 	EXF *ep;
@@ -620,11 +587,7 @@ db_rget(
  * PUBLIC: int db_rset(SCR *, recno_t, char *, size_t);
  */
 int
-db_rset(
-	SCR *sp,
-	recno_t lno,
-	char *p,
-	size_t len)
+db_rset(SCR *sp, recno_t lno, char *p, size_t len)
 {
 	DBT data, key;
 	EXF *ep;
@@ -652,9 +615,7 @@ db_rset(
  * PUBLIC: void db_err(SCR *, recno_t);
  */
 void
-db_err(
-	SCR *sp,
-	recno_t lno)
+db_err(SCR *sp, recno_t lno)
 {
 	msgq(sp, M_ERR,
 	    "008|Error: unable to retrieve line %lu", (u_long)lno);
@@ -666,11 +627,7 @@ db_err(
  *	just changed.
  */
 static int
-scr_update(
-	SCR *sp,
-	recno_t lno,
-	lnop_t op,
-	int current)
+scr_update(SCR *sp, recno_t lno, lnop_t op, int current)
 {
 	EXF *ep;
 	SCR *tsp;

--- a/common/log.c
+++ b/common/log.c
@@ -93,9 +93,7 @@ typedef struct {
  * PUBLIC: int log_init(SCR *, EXF *);
  */
 int
-log_init(
-	SCR *sp,
-	EXF *ep)
+log_init(SCR *sp, EXF *ep)
 {
 	/*
 	 * !!!
@@ -129,9 +127,7 @@ log_init(
  * PUBLIC: int log_end(SCR *, EXF *);
  */
 int
-log_end(
-	SCR *sp,
-	EXF *ep)
+log_end(SCR *sp, EXF *ep)
 {
 	/*
 	 * !!!
@@ -224,10 +220,7 @@ log_cursor1(
  * PUBLIC: int log_line(SCR *, recno_t, u_int);
  */
 int
-log_line(
-	SCR *sp,
-	recno_t lno,
-	u_int action)
+log_line(SCR *sp, recno_t lno, u_int action)
 {
 	DBT data, key;
 	EXF *ep;
@@ -327,9 +320,7 @@ log_line(
  * PUBLIC: int log_mark(SCR *, LMARK *);
  */
 int
-log_mark(
-	SCR *sp,
-	LMARK *lmp)
+log_mark(SCR *sp, LMARK *lmp)
 {
 	DBT data, key;
 	EXF *ep;
@@ -373,9 +364,7 @@ log_mark(
  * PUBLIC: int log_backward(SCR *, MARK *);
  */
 int
-log_backward(
-	SCR *sp,
-	MARK *rp)
+log_backward(SCR *sp, MARK *rp)
 {
 	DBT key, data;
 	EXF *ep;
@@ -561,9 +550,7 @@ err:	F_CLR(ep, F_NOLOG);
  * PUBLIC: int log_forward(SCR *, MARK *);
  */
 int
-log_forward(
-	SCR *sp,
-	MARK *rp)
+log_forward(SCR *sp, MARK *rp)
 {
 	DBT key, data;
 	EXF *ep;
@@ -658,10 +645,7 @@ err:	F_CLR(ep, F_NOLOG);
  *	Try and restart the log on failure, i.e. if we run out of memory.
  */
 static void
-log_err(
-	SCR *sp,
-	char *file,
-	int line)
+log_err(SCR *sp, char *file, int line)
 {
 	EXF *ep;
 
@@ -674,11 +658,7 @@ log_err(
 
 #if defined(DEBUG) && 0
 static void
-log_trace(
-	SCR *sp,
-	char *msg,
-	recno_t rno,
-	u_char *p)
+log_trace(SCR *sp, char *msg, recno_t rno, u_char *p)
 {
 	LMARK lm;
 	MARK m;
@@ -729,12 +709,8 @@ log_trace(
  *	Apply a realigned line from the log db to the file db.
  */
 static int
-apply_with(
-	int (*db_func)(SCR *, recno_t, CHAR_T *, size_t),
-	SCR *sp,
-	recno_t lno,
-	u_char *p,
-	size_t len)
+apply_with(int (*db_func)(SCR *, recno_t, CHAR_T *, size_t), SCR *sp,
+    recno_t lno, u_char *p, size_t len)
 {
 #ifdef USE_WIDECHAR
 	typedef unsigned long nword;

--- a/common/main.c
+++ b/common/main.c
@@ -41,10 +41,7 @@ static int	 v_obsolete(char *, char *[]);
  * PUBLIC: int editor(GS *, int, char *[]);
  */
 int
-editor(
-	GS *gp,
-	int argc,
-	char *argv[])
+editor(GS *gp, int argc, char *argv[])
 {
 	extern int optind;
 	extern char *optarg;
@@ -515,9 +512,7 @@ v_end(gp)
  *	Convert historic arguments into something getopt(3) will like.
  */
 static int
-v_obsolete(
-	char *name,
-	char *argv[])
+v_obsolete(char *name, char *argv[])
 {
 	size_t len;
 	char *p;
@@ -593,10 +588,7 @@ attach(GS *gp)
 #endif
 
 static void
-v_estr(
-	char *name,
-	int eno,
-	char *msg)
+v_estr(char *name, int eno, char *msg)
 {
 	(void)fprintf(stderr, "%s", name);
 	if (msg != NULL)

--- a/common/mark.c
+++ b/common/mark.c
@@ -66,9 +66,7 @@ static LMARK *mark_find(SCR *, ARG_CHAR_T);
  * PUBLIC: int mark_init(SCR *, EXF *);
  */
 int
-mark_init(
-	SCR *sp,
-	EXF *ep)
+mark_init(SCR *sp, EXF *ep)
 {
 	/*
 	 * !!!
@@ -87,9 +85,7 @@ mark_init(
  * PUBLIC: int mark_end(SCR *, EXF *);
  */
 int
-mark_end(
-	SCR *sp,
-	EXF *ep)
+mark_end(SCR *sp, EXF *ep)
 {
 	LMARK *lmp;
 
@@ -111,11 +107,7 @@ mark_end(
  * PUBLIC: int mark_get(SCR *, ARG_CHAR_T, MARK *, mtype_t);
  */
 int
-mark_get(
-	SCR *sp,
-	ARG_CHAR_T key,
-	MARK *mp,
-	mtype_t mtype)
+mark_get(SCR *sp, ARG_CHAR_T key, MARK *mp, mtype_t mtype)
 {
 	LMARK *lmp;
 
@@ -156,11 +148,7 @@ mark_get(
  * PUBLIC: int mark_set(SCR *, ARG_CHAR_T, MARK *, int);
  */
 int
-mark_set(
-	SCR *sp,
-	ARG_CHAR_T key,
-	MARK *value,
-	int userset)
+mark_set(SCR *sp, ARG_CHAR_T key, MARK *value, int userset)
 {
 	LMARK *lmp, *lmt;
 
@@ -198,9 +186,7 @@ mark_set(
  *	where it would go.
  */
 static LMARK *
-mark_find(
-	SCR *sp,
-	ARG_CHAR_T key)
+mark_find(SCR *sp, ARG_CHAR_T key)
 {
 	LMARK *lmp, *lastlmp = NULL;
 
@@ -223,10 +209,7 @@ mark_find(
  * PUBLIC: int mark_insdel(SCR *, lnop_t, recno_t);
  */
 int
-mark_insdel(
-	SCR *sp,
-	lnop_t op,
-	recno_t lno)
+mark_insdel(SCR *sp, lnop_t op, recno_t lno)
 {
 	LMARK *lmp;
 	recno_t lline;

--- a/common/msg.c
+++ b/common/msg.c
@@ -39,11 +39,7 @@ static const char sccsid[] = "$Id: msg.c,v 11.0 2012/10/17 06:34:37 zy Exp $";
  * PUBLIC: void msgq(SCR *, mtype_t, const char *, ...);
  */
 void
-msgq(
-	SCR *sp,
-	mtype_t mt,
-	const char *fmt,
-	...)
+msgq(SCR *sp, mtype_t mt, const char *fmt, ...)
 {
 #ifndef NL_ARGMAX
 #define	__NL_ARGMAX	20		/* Set to 9 by System V. */
@@ -359,11 +355,7 @@ alloc_err:
  * PUBLIC: void msgq_wstr(SCR *, mtype_t, const CHAR_T *, const char *);
  */
 void
-msgq_wstr(
-	SCR *sp,
-	mtype_t mtype,
-	const CHAR_T *str,
-	const char *fmt)
+msgq_wstr(SCR *sp, mtype_t mtype, const CHAR_T *str, const char *fmt)
 {
 	size_t nlen;
 	CONST char *nstr;
@@ -383,11 +375,7 @@ msgq_wstr(
  * PUBLIC: void msgq_str(SCR *, mtype_t, const char *, const char *);
  */
 void
-msgq_str(
-	SCR *sp,
-	mtype_t mtype,
-	const char *str,
-	const char *fmt)
+msgq_str(SCR *sp, mtype_t mtype, const char *str, const char *fmt)
 {
 	int nf, sv_errno;
 	char *p;
@@ -536,10 +524,7 @@ alloc_err:
  * PUBLIC: void msgq_status(SCR *, recno_t, u_int);
  */
 void
-msgq_status(
-	SCR *sp,
-	recno_t lno,
-	u_int flags)
+msgq_status(SCR *sp, recno_t lno, u_int flags)
 {
 	recno_t last;
 	size_t blen, len;
@@ -708,9 +693,7 @@ alloc_err:
  * PUBLIC: int msg_open(SCR *, char *);
  */
 int
-msg_open(
-	SCR *sp,
-	char *file)
+msg_open(SCR *sp, char *file)
 {
 	/*
 	 * !!!
@@ -788,10 +771,7 @@ msg_close(GS *gp)
  * PUBLIC: const char *msg_cmsg(SCR *, cmsg_t, size_t *);
  */
 const char *
-msg_cmsg(
-	SCR *sp,
-	cmsg_t which,
-	size_t *lenp)
+msg_cmsg(SCR *sp, cmsg_t which, size_t *lenp)
 {
 	switch (which) {
 	case CMSG_CONF:
@@ -826,10 +806,7 @@ msg_cmsg(
  * PUBLIC: const char *msg_cat(SCR *, const char *, size_t *);
  */
 const char *
-msg_cat(
-	SCR *sp,
-	const char *str,
-	size_t *lenp)
+msg_cat(SCR *sp, const char *str, size_t *lenp)
 {
 	GS *gp;
 	char *p;
@@ -864,10 +841,7 @@ msg_cat(
  * PUBLIC: char *msg_print(SCR *, const char *, int *);
  */
 char *
-msg_print(
-	SCR *sp,
-	const char *s,
-	int *needfree)
+msg_print(SCR *sp, const char *s, int *needfree)
 {
 	size_t blen, nlen;
 	char *bp, *ep, *p, *t;

--- a/common/options.c
+++ b/common/options.c
@@ -297,9 +297,7 @@ static OABBREV const abbrev[] = {
  * PUBLIC: int opts_init(SCR *, int *);
  */
 int
-opts_init(
-	SCR *sp,
-	int *oargs)
+opts_init(SCR *sp, int *oargs)
 {
 	ARGS *argv[2], a, b;
 	OPTLIST const *op;
@@ -463,10 +461,7 @@ err:	msgq_wstr(sp, M_ERR, optlist[optindx].name,
  * PUBLIC: int opts_set(SCR *, ARGS *[], char *);
  */
 int
-opts_set(
-	SCR *sp,
-	ARGS *argv[],
-	char *usage)
+opts_set(SCR *sp, ARGS *argv[], char *usage)
 {
 	enum optdisp disp;
 	enum nresult nret;
@@ -757,12 +752,7 @@ badnum:				INT2CHAR(sp, name, STRLEN(name) + 1,
  * PUBLIC: int o_set(SCR *, int, u_int, char *, u_long);
  */
 int
-o_set(
-	SCR *sp,
-	int opt,
-	u_int flags,
-	char *str,
-	u_long val)
+o_set(SCR *sp, int opt, u_int flags, char *str, u_long val)
 {
 	OPTION *op;
 
@@ -801,10 +791,7 @@ o_set(
  * PUBLIC: int opts_empty(SCR *, int, int);
  */
 int
-opts_empty(
-	SCR *sp,
-	int off,
-	int silent)
+opts_empty(SCR *sp, int off, int silent)
 {
 	char *p;
 
@@ -824,9 +811,7 @@ opts_empty(
  * PUBLIC: void opts_dump(SCR *, enum optdisp);
  */
 void
-opts_dump(
-	SCR *sp,
-	enum optdisp type)
+opts_dump(SCR *sp, enum optdisp type)
 {
 	OPTLIST const *op;
 	int base, b_num, cnt, col, colwidth, curlen, s_num;
@@ -958,9 +943,7 @@ opts_dump(
  *	Print out an option.
  */
 static int
-opts_print(
-	SCR *sp,
-	OPTLIST const *op)
+opts_print(SCR *sp, OPTLIST const *op)
 {
 	int curlen, offset;
 
@@ -990,9 +973,7 @@ opts_print(
  * PUBLIC: int opts_save(SCR *, FILE *);
  */
 int
-opts_save(
-	SCR *sp,
-	FILE *fp)
+opts_save(SCR *sp, FILE *fp)
 {
 	OPTLIST const *op;
 	CHAR_T ch, *p;
@@ -1093,26 +1074,20 @@ opts_search(CHAR_T *name)
  * PUBLIC: void opts_nomatch(SCR *, CHAR_T *);
  */
 void
-opts_nomatch(
-	SCR *sp,
-	CHAR_T *name)
+opts_nomatch(SCR *sp, CHAR_T *name)
 {
 	msgq_wstr(sp, M_ERR, name,
 	    "033|set: no %s option: 'set all' gives all option values");
 }
 
 static int
-opts_abbcmp(
-	const void *a,
-	const void *b)
+opts_abbcmp(const void *a, const void *b)
 {
 	return(STRCMP(((OABBREV *)a)->name, ((OABBREV *)b)->name));
 }
 
 static int
-opts_cmp(
-	const void *a,
-	const void *b)
+opts_cmp(const void *a, const void *b)
 {
 	return(STRCMP(((OPTLIST *)a)->name, ((OPTLIST *)b)->name));
 }
@@ -1124,9 +1099,7 @@ opts_cmp(
  * PUBLIC: int opts_copy(SCR *, SCR *);
  */
 int
-opts_copy(
-	SCR *orig,
-	SCR *sp)
+opts_copy(SCR *orig, SCR *sp)
 {
 	int cnt, rval;
 

--- a/common/options_f.c
+++ b/common/options_f.c
@@ -32,11 +32,7 @@ static const char sccsid[] = "$Id: options_f.c,v 10.34 04/07/11 16:06:29 zy Exp 
  * PUBLIC: int f_altwerase(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_altwerase(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_altwerase(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	if (*valp)
 		O_CLR(sp, O_TTYWERASE);
@@ -47,11 +43,7 @@ f_altwerase(
  * PUBLIC: int f_columns(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_columns(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_columns(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	/* Validate the number. */
 	if (*valp < MINIMUM_SCREEN_COLS) {
@@ -81,11 +73,7 @@ f_columns(
  * PUBLIC: int f_lines(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_lines(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_lines(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	/* Validate the number. */
 	if (*valp < MINIMUM_SCREEN_ROWS) {
@@ -138,11 +126,7 @@ f_lines(
  * PUBLIC: int f_lisp(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_lisp(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_lisp(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	msgq(sp, M_ERR, "044|The lisp option is not implemented");
 	return (0);
@@ -152,11 +136,7 @@ f_lisp(
  * PUBLIC: int f_msgcat(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_msgcat(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_msgcat(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	(void)msg_open(sp, str);
 	return (0);
@@ -166,11 +146,7 @@ f_msgcat(
  * PUBLIC: int f_print(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_print(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_print(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	int offset = op - sp->opts;
 
@@ -195,11 +171,7 @@ f_print(
  * PUBLIC: int f_readonly(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_readonly(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_readonly(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	/*
 	 * !!!
@@ -216,11 +188,7 @@ f_readonly(
  * PUBLIC: int f_recompile(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_recompile(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_recompile(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	if (F_ISSET(sp, SC_RE_SEARCH)) {
 		regfree(&sp->re_c);
@@ -237,11 +205,7 @@ f_recompile(
  * PUBLIC: int f_reformat(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_reformat(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_reformat(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	F_SET(sp, SC_SCR_REFORMAT);
 	return (0);
@@ -251,11 +215,7 @@ f_reformat(
  * PUBLIC: int f_ttywerase(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_ttywerase(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_ttywerase(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	if (*valp)
 		O_CLR(sp, O_ALTWERASE);
@@ -329,11 +289,7 @@ f_w9600(
  * PUBLIC: int f_window(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_window(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_window(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	if (*valp >= O_VAL(sp, O_LINES) - 1 &&
 	    (*valp = O_VAL(sp, O_LINES) - 1) == 0)
@@ -345,11 +301,7 @@ f_window(
  * PUBLIC: int f_encoding(SCR *, OPTION *, char *, u_long *);
  */
 int
-f_encoding(
-	SCR *sp,
-	OPTION *op,
-	char *str,
-	u_long *valp)
+f_encoding(SCR *sp, OPTION *op, char *str, u_long *valp)
 {
 	int offset = op - sp->opts;
 

--- a/common/put.c
+++ b/common/put.c
@@ -33,13 +33,7 @@ static const char sccsid[] = "$Id: put.c,v 10.19 04/07/11 17:00:24 zy Exp $";
  * PUBLIC: int put(SCR *, CB *, CHAR_T *, MARK *, MARK *, int);
  */
 int
-put(
-	SCR *sp,
-	CB *cbp,
-	CHAR_T *namep,
-	MARK *cp,
-	MARK *rp,
-	int append)
+put(SCR *sp, CB *cbp, CHAR_T *namep, MARK *cp, MARK *rp, int append)
 {
 	CHAR_T name;
 	TEXT *ltp, *tp;

--- a/common/recover.c
+++ b/common/recover.c
@@ -116,10 +116,7 @@ static int	 rcv_dlnread(SCR *, char **, char **, FILE *);
  * PUBLIC: int rcv_tmp(SCR *, EXF *, char *);
  */
 int
-rcv_tmp(
-	SCR *sp,
-	EXF *ep,
-	char *name)
+rcv_tmp(SCR *sp, EXF *ep, char *name)
 {
 	struct stat sb;
 	int fd;
@@ -237,9 +234,7 @@ err:	msgq(sp, M_ERR,
  * PUBLIC: int rcv_sync(SCR *, u_int);
  */
 int
-rcv_sync(
-	SCR *sp,
-	u_int flags)
+rcv_sync(SCR *sp, u_int flags)
 {
 	EXF *ep;
 	int fd, rval;
@@ -321,10 +316,7 @@ err:		rval = 1;
  *	Build the file to mail to the user.
  */
 static int
-rcv_mailfile(
-	SCR *sp,
-	int issync,
-	char *cp_path)
+rcv_mailfile(SCR *sp, int issync, char *cp_path)
 {
 	EXF *ep;
 	GS *gp;
@@ -615,9 +607,7 @@ next:		(void)fclose(fp);
  * PUBLIC: int rcv_read(SCR *, FREF *);
  */
 int
-rcv_read(
-	SCR *sp,
-	FREF *frp)
+rcv_read(SCR *sp, FREF *frp)
 {
 	struct dirent *dp;
 	struct stat sb;
@@ -793,10 +783,7 @@ next:			free(recpath);
  *	Copy a recovery file.
  */
 static int
-rcv_copy(
-	SCR *sp,
-	int wfd,
-	char *fname)
+rcv_copy(SCR *sp, int wfd, char *fname)
 {
 	int nr, nw, off, rfd;
 	char buf[8 * 1024];
@@ -819,10 +806,7 @@ err:	msgq_str(sp, M_SYSERR, fname, "%s");
  *	Paranoid make temporary file routine.
  */
 static int
-rcv_mktemp(
-	SCR *sp,
-	char *path,
-	char *dname)
+rcv_mktemp(SCR *sp, char *path, char *dname)
 {
 	int fd;
 
@@ -836,9 +820,7 @@ rcv_mktemp(
  *	Send email.
  */
 static void
-rcv_email(
-	SCR *sp,
-	char *fname)
+rcv_email(SCR *sp, char *fname)
 {
 	char *buf;
 
@@ -857,11 +839,7 @@ rcv_email(
  *	Encode a string into an X-vi-data line and write it.
  */
 static int
-rcv_dlnwrite(
-	SCR *sp,
-	const char *dtype,
-	const char *src,
-	FILE *fp)
+rcv_dlnwrite(SCR *sp, const char *dtype, const char *src, FILE *fp)
 {
 	char *bp = NULL, *p;
 	size_t blen = 0;
@@ -904,11 +882,7 @@ alloc_err:
  *	Read an X-vi-data line and decode it.
  */
 static int
-rcv_dlnread(
-	SCR *sp,
-	char **dtypep,
-	char **datap,		/* free *datap if != NULL after use. */
-	FILE *fp)
+rcv_dlnread(SCR *sp, char **dtypep, char **datap, FILE *fp)
 {
 	int ch;
 	char buf[1024];

--- a/common/screen.c
+++ b/common/screen.c
@@ -35,10 +35,7 @@ static const char sccsid[] = "$Id: screen.c,v 10.25 2011/12/04 04:06:45 zy Exp $
  * PUBLIC: int screen_init(GS *, SCR *, SCR **);
  */
 int
-screen_init(
-	GS *gp,
-	SCR *orig,
-	SCR **spp)
+screen_init(GS *gp, SCR *orig, SCR **spp)
 {
 	SCR *sp;
 	size_t len;

--- a/common/search.c
+++ b/common/search.c
@@ -38,13 +38,8 @@ static int	search_init(SCR *, dir_t, CHAR_T *, size_t, CHAR_T **, u_int);
  *	Set up a search.
  */
 static int
-search_init(
-	SCR *sp,
-	dir_t dir,
-	CHAR_T *ptrn,
-	size_t plen,
-	CHAR_T **epp,
-	u_int flags)
+search_init(SCR *sp, dir_t dir, CHAR_T *ptrn, size_t plen, CHAR_T **epp,
+    u_int flags)
 {
 	recno_t lno;
 	int delim;
@@ -146,14 +141,8 @@ prev:			if (sp->re == NULL) {
  * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int);
  */
 int
-f_search(
-	SCR *sp,
-	MARK *fm,
-	MARK *rm,
-	CHAR_T *ptrn,
-	size_t plen,
-	CHAR_T **eptrn,
-	u_int flags)
+f_search(SCR *sp, MARK *fm, MARK *rm, CHAR_T *ptrn, size_t plen,
+    CHAR_T **eptrn, u_int flags)
 {
 	busy_t btype;
 	recno_t lno;
@@ -292,14 +281,8 @@ f_search(
  * PUBLIC:    MARK *, MARK *, CHAR_T *, size_t, CHAR_T **, u_int);
  */
 int
-b_search(
-	SCR *sp,
-	MARK *fm,
-	MARK *rm,
-	CHAR_T *ptrn,
-	size_t plen,
-	CHAR_T **eptrn,
-	u_int flags)
+b_search(SCR *sp, MARK *fm, MARK *rm, CHAR_T *ptrn, size_t plen,
+    CHAR_T **eptrn, u_int flags)
 {
 	busy_t btype;
 	recno_t lno;
@@ -453,9 +436,7 @@ err:	if (LF_ISSET(SEARCH_MSG))
  *	Display one of the search messages.
  */
 static void
-search_msg(
-	SCR *sp,
-	smsg_t msg)
+search_msg(SCR *sp, smsg_t msg)
 {
 	switch (msg) {
 	case S_EMPTY:
@@ -490,9 +471,7 @@ search_msg(
  * PUBLIC: void search_busy(SCR *, busy_t);
  */
 void
-search_busy(
-	SCR *sp,
-	busy_t btype)
+search_busy(SCR *sp, busy_t btype)
 {
 	sp->gp->scr_busy(sp, "078|Searching...", btype);
 }

--- a/common/seq.c
+++ b/common/seq.c
@@ -35,16 +35,8 @@ static const char sccsid[] = "$Id: seq.c,v 10.18 2011/12/11 23:13:00 zy Exp $";
  * PUBLIC:    size_t, CHAR_T *, size_t, CHAR_T *, size_t, seq_t, int);
  */
 int
-seq_set(
-	SCR *sp,
-	CHAR_T *name,
-	size_t nlen,
-	CHAR_T *input,
-	size_t ilen,
-	CHAR_T *output,
-	size_t olen,
-	seq_t stype,
-	int flags)
+seq_set(SCR *sp, CHAR_T *name, size_t nlen, CHAR_T *input, size_t ilen,
+    CHAR_T *output, size_t olen, seq_t stype, int flags)
 {
 	CHAR_T *p;
 	SEQ *lastqp, *qp;
@@ -139,11 +131,7 @@ mem1:		errno = sv_errno;
  * PUBLIC: int seq_delete(SCR *, CHAR_T *, size_t, seq_t);
  */
 int
-seq_delete(
-	SCR *sp,
-	CHAR_T *input,
-	size_t ilen,
-	seq_t stype)
+seq_delete(SCR *sp, CHAR_T *input, size_t ilen, seq_t stype)
 {
 	SEQ *qp, *pre_qp = NULL;
 	int diff;
@@ -196,14 +184,8 @@ seq_free(SEQ *qp)
  * PUBLIC:   (SCR *, SEQ **, EVENT *, CHAR_T *, size_t, seq_t, int *);
  */
 SEQ *
-seq_find(
-	SCR *sp,
-	SEQ **lastqp,
-	EVENT *e_input,
-	CHAR_T *c_input,
-	size_t ilen,
-	seq_t stype,
-	int *ispartialp)
+seq_find(SCR *sp, SEQ **lastqp, EVENT *e_input, CHAR_T *c_input, size_t ilen,
+    seq_t stype, int *ispartialp)
 {
 	SEQ *lqp = NULL, *qp;
 	int diff;
@@ -298,10 +280,7 @@ seq_close(GS *gp)
  * PUBLIC: int seq_dump(SCR *, seq_t, int);
  */
 int
-seq_dump(
-	SCR *sp,
-	seq_t stype,
-	int isname)
+seq_dump(SCR *sp, seq_t stype, int isname)
 {
 	CHAR_T *p;
 	GS *gp;
@@ -346,11 +325,7 @@ seq_dump(
  * PUBLIC: int seq_save(SCR *, FILE *, char *, seq_t);
  */
 int
-seq_save(
-	SCR *sp,
-	FILE *fp,
-	char *prefix,
-	seq_t stype)
+seq_save(SCR *sp, FILE *fp, char *prefix, seq_t stype)
 {
 	CHAR_T *p;
 	SEQ *qp;
@@ -392,10 +367,7 @@ seq_save(
  * PUBLIC: int e_memcmp(CHAR_T *, EVENT *, size_t);
  */
 int
-e_memcmp(
-	CHAR_T *p1,
-	EVENT *ep,
-	size_t n)
+e_memcmp(CHAR_T *p1, EVENT *ep, size_t n)
 {
 	if (n != 0) {
 		do {

--- a/common/util.c
+++ b/common/util.c
@@ -42,11 +42,7 @@ static const char sccsid[] = "$Id: util.c,v 10.30 2013/03/19 10:00:27 yamt Exp $
  * PUBLIC: void *binc(SCR *, void *, size_t *, size_t);
  */
 void *
-binc(
-	SCR *sp,			/* sp MAY BE NULL!!! */
-	void *bp,
-	size_t *bsizep,
-	size_t min)
+binc(SCR *sp, void *bp, size_t *bsizep, size_t min)
 {
 	size_t csize;
 
@@ -79,10 +75,7 @@ binc(
  * PUBLIC: int nonblank(SCR *, recno_t, size_t *);
  */
 int
-nonblank(
-	SCR *sp,
-	recno_t lno,
-	size_t *cnop)
+nonblank(SCR *sp, recno_t lno, size_t *cnop)
 {
 	CHAR_T *p;
 	size_t cnt, len, off;
@@ -131,9 +124,7 @@ tail(char *path)
  * PUBLIC: char *join(char *, char *);
  */
 char *
-join(
-	char *path1,
-	char *path2)
+join(char *path1, char *path2)
 {
 	char *p;
 
@@ -248,10 +239,7 @@ quote(char *str)
  * PUBLIC: char *v_strdup(SCR *, const char *, size_t);
  */
 char *
-v_strdup(
-	SCR *sp,
-	const char *str,
-	size_t len)
+v_strdup(SCR *sp, const char *str, size_t len)
 {
 	char *copy;
 
@@ -291,11 +279,7 @@ v_wstrdup(SCR *sp,
  * PUBLIC: enum nresult nget_uslong(u_long *, const CHAR_T *, CHAR_T **, int);
  */
 enum nresult
-nget_uslong(
-	u_long *valp,
-	const CHAR_T *p,
-	CHAR_T **endp,
-	int base)
+nget_uslong(u_long *valp, const CHAR_T *p, CHAR_T **endp, int base)
 {
 	errno = 0;
 	*valp = STRTOUL(p, endp, base);
@@ -313,11 +297,7 @@ nget_uslong(
  * PUBLIC: enum nresult nget_slong(long *, const CHAR_T *, CHAR_T **, int);
  */
 enum nresult
-nget_slong(
-	long *valp,
-	const CHAR_T *p,
-	CHAR_T **endp,
-	int base)
+nget_slong(long *valp, const CHAR_T *p, CHAR_T **endp, int base)
 {
 	errno = 0;
 	*valp = STRTOL(p, endp, base);
@@ -339,8 +319,7 @@ nget_slong(
  * PUBLIC: void timepoint_steady(struct timespec *);
  */
 void
-timepoint_steady(
-	struct timespec *ts)
+timepoint_steady(struct timespec *ts)
 {
 #ifdef __APPLE__
 	static mach_timebase_info_data_t base = { 0 };
@@ -370,8 +349,7 @@ timepoint_steady(
  * PUBLIC: void timepoint_system(struct timespec *);
  */
 void
-timepoint_system(
-	struct timespec *ts)
+timepoint_system(struct timespec *ts)
 {
 #ifdef __APPLE__
 	clock_serv_t clk;
@@ -404,10 +382,7 @@ timepoint_system(
  * PUBLIC: void TRACE(SCR *, const char *, ...);
  */
 void
-TRACE(
-	SCR *sp,
-	const char *fmt,
-	...)
+TRACE(SCR *sp, const char *fmt, ...)
 {
 	FILE *tfp;
 	va_list ap;

--- a/ex/ex_print.c
+++ b/ex/ex_print.c
@@ -261,10 +261,7 @@ intr:	*colp = col;
  * PUBLIC: int ex_printf(SCR *, const char *, ...);
  */
 int
-ex_printf(
-	SCR *sp,
-	const char *fmt,
-	...)
+ex_printf(SCR *sp, const char *fmt, ...)
 {
 	EX_PRIVATE *exp;
 	va_list ap;

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -1302,13 +1302,8 @@ re_error(SCR *sp, int errcode, regex_t *preg)
  * 	Do the substitution for a regular expression.
  */
 static int
-re_sub(
-	SCR *sp,
-	CHAR_T *ip,			/* Input line. */
-	CHAR_T **lbp,
-	size_t *lbclenp,
-	size_t *lblenp,
-	regmatch_t match[10])
+re_sub(SCR *sp, CHAR_T *ip, CHAR_T **lbp, size_t *lbclenp, size_t *lblenp,
+    regmatch_t match[10])
 {
 	enum { C_NOTSET, C_LOWER, C_ONELOWER, C_ONEUPPER, C_UPPER } conv;
 	size_t lbclen, lblen;		/* Local copies. */

--- a/vi/v_txt.c
+++ b/vi/v_txt.c
@@ -238,16 +238,8 @@ txt_map_end(SCR *sp)
  * PUBLIC:    const CHAR_T *, size_t, ARG_CHAR_T, recno_t, u_long, u_int32_t);
  */
 int
-v_txt(
-	SCR *sp,
-	VICMD *vp,
-	MARK *tm,		/* To MARK. */
-	const CHAR_T *lp,	/* Input line. */
-	size_t len,		/* Input line length. */
-	ARG_CHAR_T prompt,	/* Prompt to display. */
-	recno_t ai_line,	/* Line number to use for autoindent count. */
-	u_long rcount,		/* Replay count. */
-	u_int32_t flags)	/* TXT_* flags. */
+v_txt(SCR *sp, VICMD *vp, MARK *tm, const CHAR_T *lp, size_t len,
+    ARG_CHAR_T prompt, recno_t ai_line, u_long rcount, u_int32_t flags)
 {
 	EVENT ev, *evp = NULL;	/* Current event. */
 	EVENT fc;		/* File name completion event. */

--- a/vi/vi.c
+++ b/vi/vi.c
@@ -448,13 +448,8 @@ VIKEYS const tmotion = {
  *	[count] key [character]
  */
 static gcret_t
-v_cmd(
-	SCR *sp,
-	VICMD *dp,
-	VICMD *vp,
-	VICMD *ismotion,	/* Previous key if getting motion component. */
-	int *comcountp,
-	int *mappedp)
+v_cmd(SCR *sp, VICMD *dp, VICMD *vp, VICMD *ismotion, int *comcountp,
+    int *mappedp)
 {
 	enum { COMMANDMODE, ISPARTIAL, NOTPARTIAL } cpart;
 	EVENT ev;
@@ -714,11 +709,7 @@ esc:	switch (cpart) {
  * Get resulting motion mark.
  */
 static int
-v_motion(
-	SCR *sp,
-	VICMD *dm,
-	VICMD *vp,
-	int *mappedp)
+v_motion(SCR *sp, VICMD *dm, VICMD *vp, int *mappedp)
 {
 	VICMD motion;
 	size_t len;
@@ -1092,10 +1083,7 @@ v_curword(SCR *sp)
  *	Check for a command alias.
  */
 static VIKEYS const *
-v_alias(
-	SCR *sp,
-	VICMD *vp,
-	VIKEYS const *kp)
+v_alias(SCR *sp, VICMD *vp, VIKEYS const *kp)
 {
 	CHAR_T push;
 
@@ -1128,10 +1116,7 @@ v_alias(
  *	Return the next count.
  */
 static int
-v_count(
-	SCR *sp,
-	ARG_CHAR_T fkey,
-	u_long *countp)
+v_count(SCR *sp, ARG_CHAR_T fkey, u_long *countp)
 {
 	EVENT ev;
 	u_long count, tc;
@@ -1168,11 +1153,7 @@ v_count(
  *	Return the next event.
  */
 static gcret_t
-v_key(
-	SCR *sp,
-	int command_events,
-	EVENT *evp,
-	u_int32_t ec_flags)
+v_key(SCR *sp, int command_events, EVENT *evp, u_int32_t ec_flags)
 {
 	u_int32_t quote;
 
@@ -1231,9 +1212,7 @@ v_key(
  *	Log the contents of the command structure.
  */
 static void
-v_comlog(
-	SCR *sp,
-	VICMD *vp)
+v_comlog(SCR *sp, VICMD *vp)
 {
 	TRACE(sp, "vcmd: "WC, vp->key);
 	if (F_ISSET(vp, VC_BUFFER))

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -40,9 +40,7 @@ static int	vs_paint(SCR *, u_int);
  * PUBLIC: int vs_repaint(SCR *, EVENT *);
  */
 int
-vs_repaint(
-	SCR *sp,
-	EVENT *evp)
+vs_repaint(SCR *sp, EVENT *evp)
 {
 	SMAP *smp;
 
@@ -62,9 +60,7 @@ vs_repaint(
  * PUBLIC: int vs_refresh(SCR *, int);
  */
 int
-vs_refresh(
-	SCR *sp,
-	int forcepaint)
+vs_refresh(SCR *sp, int forcepaint)
 {
 	GS *gp;
 	SCR *tsp;
@@ -159,9 +155,7 @@ vs_refresh(
  *	what you're doing.  It's subtle and quick to anger.
  */
 static int
-vs_paint(
-	SCR *sp,
-	u_int flags)
+vs_paint(SCR *sp, u_int flags)
 {
 	GS *gp;
 	SMAP *smp, tmp;

--- a/vi/vs_split.c
+++ b/vi/vs_split.c
@@ -40,10 +40,7 @@ static int	 vs_join(SCR *, SCR **, jdir_t *);
  * PUBLIC: int vs_split(SCR *, SCR *, int);
  */
 int
-vs_split(
-	SCR *sp,
-	SCR *new,
-	int ccl)		/* Colon-command line split. */
+vs_split(SCR *sp, SCR *new, int ccl)
 {
 	GS *gp;
 	SMAP *smp;


### PR DESCRIPTION
This ansifies a couple of missed K&R prototypes.

Also, conv.c and most of the ansified prototypes weren’t in KNF. This reduces the diff to OpenBSD by about 1200 lines.