### PR TITLE
Man page syntax improvements.

### DIFF
--- a/docs/man/vi.1
+++ b/docs/man/vi.1
@@ -2051,7 +2051,7 @@ If this is the entire
 pattern, the replacement part of the previous
 .Cm substitute
 command.
-.It Sq \e\(sh
+.It Sq \e Ns Ar \(sh
 Where
 .Sq Ar \(sh
 is an integer from 1 to 9, the text matched by the


### PR DESCRIPTION
- fix some incorrect macro usage and escapes
- escape ` and ' commands so they appear properly in troff PDF output
- use Unicode hyphens, apostrophes, and minus signs
