### PR TITLE
Do not rely on unspecified behavior for the size_t overflow check.

### DIFF
--- a/common/delete.c
+++ b/common/delete.c
@@ -19,7 +19,7 @@ static const char sccsid[] = "$Id: delete.c,v 10.18 2012/02/11 15:52:33 zy Exp $
 
 #include <bitstring.h>
 #include <errno.h>
-#include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -121,17 +121,11 @@ del(
 	if (db_get(sp, tm->lno, DBG_FATAL, &p, &len))
 		goto err;
 	if (len != 0 && tm->cno != len - 1) {
-		/*
-		 * XXX
-		 * We can overflow memory here, if the total length is greater
-		 * than SIZE_T_MAX.  The only portable way I've found to test
-		 * is depending on the overflow being less than the value.
-		 */
-		nlen = (len - (tm->cno + 1)) + tlen;
-		if (tlen > nlen) {
+		if (len < tm->cno + 1 || len - (tm->cno + 1) > SIZE_MAX - tlen) {
 			msgq(sp, M_ERR, "002|Line length overflow");
 			goto err;
 		}
+		nlen = (len - (tm->cno + 1)) + tlen;
 		if (tlen == 0) {
 			GET_SPACE_RETW(sp, bp, blen, nlen);
 		} else


### PR DESCRIPTION
Do not rely on unspecified behavior for the size_t overflow check.

From millert@ OpenBSD.