### PR TITLE
Reintroduce msg_cat cast to fix status line count.

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -647,7 +647,7 @@ msgq_status(
 			p += len;
 		} else {
 			t = msg_cat(sp, "027|line %lu of %lu [%ld%%]", &len);
-			(void)snprintf(p, ep - p, t, lno, last,
+			(void)snprintf(p, ep - p, t, lno, (u_long)last,
 			    ((u_long)lno * 100) / last);
 			p += strlen(p);
 		}


### PR DESCRIPTION
Commit [3e607ab] removed casts on `lno` and `last to` prevent overflow. Unfortunately, this yields an inaccurate line count. For a single-line file, nvi (running under OSX) reports

    modified: line 1 of 140733193388033 [100%]

This commit reintroduces the cast on `last` to yield

    modified: line 1 of 1 [100%]