### PR TITLE
Remove some defines.

### DIFF
--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -345,21 +345,12 @@ setsig(int signo, struct sigaction *oactp, void (*handler) (int))
 	 * Use sigaction(2), not signal(3), since we don't always want to
 	 * restart system calls.  The example is when waiting for a command
 	 * mode keystroke and SIGWINCH arrives.  Besides, you can't portably
-	 * restart system calls (thanks, POSIX!).  On the other hand, you
-	 * can't portably NOT restart system calls (thanks, Sun!).  SunOS
-	 * used SA_INTERRUPT as their extension to NOT restart read calls.
-	 * We sure hope nobody else used it for anything else.  Mom told me
-	 * there'd be days like this.  She just never told me that there'd
-	 * be so many.
+	 * restart system calls (thanks, POSIX!).
 	 */
 	act.sa_handler = handler;
 	sigemptyset(&act.sa_mask);
 
-#ifdef SA_INTERRUPT
-	act.sa_flags = SA_INTERRUPT;
-#else
 	act.sa_flags = 0;
-#endif
 	return (sigaction(signo, &act, oactp));
 }
 

--- a/ex/ex_z.c
+++ b/ex/ex_z.c
@@ -54,11 +54,7 @@ ex_z(SCR *sp, EXCMD *cmdp)
 	if (FL_ISSET(cmdp->iflags, E_C_COUNT))
 		cnt = cmdp->count;
 	else
-#ifdef HISTORICAL_PRACTICE
-		cnt = O_VAL(sp, O_SCROLL) * 2;
-#else
 		cnt = O_VAL(sp, O_WINDOW) - 1;
-#endif
 
 	equals = 0;
 	eofcheck = 0;

--- a/vi/v_mark.c
+++ b/vi/v_mark.c
@@ -196,22 +196,7 @@ mark(SCR *sp, VICMD *vp, int getmark, enum which cmd)
 	 * Delete cursor motion was always to the start of the text region,
 	 * regardless.  Ignore other motion commands.
 	 */
-#ifdef HISTORICAL_PRACTICE
-	if (ISCMD(vp->rkp, 'y')) {
-		if ((cmd == BQMARK ||
-		    (cmd == FQMARK && vp->m_start.lno != vp->m_stop.lno)) &&
-		    (vp->m_start.lno > vp->m_stop.lno ||
-		    (vp->m_start.lno == vp->m_stop.lno &&
-		    vp->m_start.cno > vp->m_stop.cno)))
-			vp->m_final = vp->m_stop;
-	} else if (ISCMD(vp->rkp, 'd'))
-		if (vp->m_start.lno > vp->m_stop.lno ||
-		    (vp->m_start.lno == vp->m_stop.lno &&
-		    vp->m_start.cno > vp->m_stop.cno))
-			vp->m_final = vp->m_stop;
-#else
 	vp->m_final = vp->m_start;
-#endif
 
 	/*
 	 * Forward marks are always line oriented, and it's set in the


### PR DESCRIPTION
HISTORICAL_PRACTICE is never defined.

SA_INTERRUPT is for SunOS support which is pretty irrelevant these days.

From bcallah@openbsd.