### PR TITLE
WIP: window resizing without restarting terminal

### DIFF
--- a/cl/cl_screen.c
+++ b/cl/cl_screen.c
@@ -56,8 +56,13 @@ cl_screen(SCR *sp, u_int32_t flags)
 	clp = CLP(sp);
 	win = CLSP(sp) ? CLSP(sp) : stdscr;
 
+	if (F_ISSET(gp, G_WRESIZE))
+	{
+		resizeterm(O_VAL(sp, O_LINES), O_VAL(sp, O_COLUMNS));
+		F_CLR(gp, G_WRESIZE | G_SRESTART);
+	}
 	/* See if the current information is incorrect. */
-	if (F_ISSET(gp, G_SRESTART)) {
+	else if (F_ISSET(gp, G_SRESTART)) {
 		if (CLSP(sp)) {
 		    delwin(CLSP(sp));
 		    sp->cl_private = NULL;

--- a/cl/cl_term.c
+++ b/cl/cl_term.c
@@ -270,6 +270,8 @@ cl_optchange(SCR *sp, int opt, char *str, u_long *valp)
 	switch (opt) {
 	case O_COLUMNS:
 	case O_LINES:
+		F_SET(sp->gp, G_WRESIZE | G_SRESTART);
+		break;
 	case O_TERM:
 		/*
 		 * Changing the columns, lines or terminal require that

--- a/common/gs.h
+++ b/common/gs.h
@@ -140,6 +140,7 @@ struct _gs {
 #define	G_SNAPSHOT	0x0040		/* Always snapshot files. */
 #define	G_SRESTART	0x0080		/* Screen restarted. */
 #define	G_TMP_INUSE	0x0100		/* Temporary buffer in use. */
+#define	G_WRESIZE	0x0200
 	u_int32_t flags;
 
 	/* Screen interface functions. */


### PR DESCRIPTION
When resize the curses screen, nvi ends screen, recreates it with `newterm(3X)`, deeply reinitialize ex/vi.  When `newterm(3X)` has memory leak, nvi leaks a lot when you use mouse to resize the X terminal.

NetBSD attempted[1] to solve this problem by replacing subsequent calls to `newterm(3X)` with `setterm(3X)` + `resizeterm(3X)`.  But ncurses' `setterm`/`setupterm` has problem being called on an established screen.

My plan is to use `resizeterm(3X)` to do resizing, and keep using `newterm(3X)` to change terminal type (at runtime, e.g., `:se term=cons25`).  This patch registers a new global state to tell cl to do a "lightweight" resizing.  When using it, we still tell ex/vi to exit current loop, but simply reenter the loop after we call `resizeterm` in cl code.

Benefits observed:
  - After performing a manual resizing in nvi (eg, `se lines=20`), the terminal is no longer affected after nvi exits.
  - In an ex switched from vi, calling `se lines=20` no longer affects ex (it's pointless to reposition ex prompt once and let it go beyond; ex has no screen and should not be limited to vi screen from the beginning).

Problem observed:

 - When resizing a screen with a `:vsplit` window, nvi prompts "n screens backgrounded; use :display to list them".  Resizing leaves only one active window, and backgrounding does show this message, but this message should never show when resizing, because the message will prevent text reflow.  Not a serious break though.

[1] http://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=25849

@bentley can you help me test this?  Thanks!