### PR TITLE
Fix incompatible behaviour of T during motion

### DIFF
--- a/vi/v_ch.c
+++ b/vi/v_ch.c
@@ -197,6 +197,15 @@ v_chT(SCR *sp, VICMD *vp)
 		return (1);
 
 	/*
+	 * Check whether the matching character is to the immediate left
+	 * of the original cursor position, offset adjusted for a motion
+	 * command.  If so, no movement is required.
+	 */
+	if (vp->m_start.cno == vp->m_stop.cno) {
+                return (1);
+	}
+
+	/*
 	 * v_chF places the cursor on the character, where the 'T'
 	 * command wants it to its right.  We know this is safe since
 	 * we had to move left for v_chF() to have succeeded.


### PR DESCRIPTION
Given the line

    foo bar baz
              ^

with the cursor at EOL (marked with a caret), delete backwards with `dTb`:

    foo bar bz
             ^

Repeating `dTb` yields

    foo bar 
           ^

Expected result (as seen in [ex-vi](http://ex-vi.sourceforge.net/), [vile](http://invisible-island.net/vile) and [vim](http://www.vim.org/)):

    foo bar bz
             ^

i.e., the second deletion should be a noop.