### PR TITLE
Remove type casts from allocation macros

### DIFF
--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -172,7 +172,7 @@ gs_init(char *name)
 		name = p + 1;
 
 	/* Allocate the global structure. */
-	CALLOC_NOMSG(NULL, gp, GS *, 1, sizeof(GS));
+	CALLOC_NOMSG(NULL, gp, 1, sizeof(GS));
 	if (gp == NULL)
 		perr(name, NULL);
 
@@ -191,7 +191,7 @@ cl_init(GS *gp)
 	int fd;
 
 	/* Allocate the CL private structure. */
-	CALLOC_NOMSG(NULL, clp, CL_PRIVATE *, 1, sizeof(CL_PRIVATE));
+	CALLOC_NOMSG(NULL, clp, 1, sizeof(CL_PRIVATE));
 	if (clp == NULL)
 		perr(gp->progname, NULL);
 	gp->cl_private = clp;

--- a/cl/cl_screen.c
+++ b/cl/cl_screen.c
@@ -526,7 +526,7 @@ cl_getcap(SCR *sp, char *name, char **elementp)
 
 	if ((t = tigetstr(name)) != NULL &&
 	    t != (char *)-1 && (len = strlen(t)) != 0) {
-		MALLOC_RET(sp, *elementp, char *, len + 1);
+		MALLOC_RET(sp, *elementp, len + 1);
 		memmove(*elementp, t, len + 1);
 	}
 	return (0);

--- a/common/cut.c
+++ b/common/cut.c
@@ -126,7 +126,7 @@ copyloop:
 	 * Otherwise, if it's not an append, free its current contents.
 	 */
 	if (cbp == NULL) {
-		CALLOC_RET(sp, cbp, CB *, 1, sizeof(CB));
+		CALLOC_RET(sp, cbp, 1, sizeof(CB));
 		cbp->name = name;
 		TAILQ_INIT(cbp->textq);
 		SLIST_INSERT_HEAD(sp->gp->cutq, cbp, q);
@@ -302,12 +302,12 @@ text_init(
 {
 	TEXT *tp;
 
-	CALLOC(sp, tp, TEXT *, 1, sizeof(TEXT));
+	CALLOC(sp, tp, 1, sizeof(TEXT));
 	if (tp == NULL)
 		return (NULL);
 	/* ANSI C doesn't define a call to malloc(3) for 0 bytes. */
 	if ((tp->lb_len = total_len * sizeof(CHAR_T)) != 0) {
-		MALLOC(sp, tp->lb, CHAR_T *, tp->lb_len);
+		MALLOC(sp, tp->lb, tp->lb_len);
 		if (tp->lb == NULL) {
 			free(tp);
 			return (NULL);

--- a/common/exf.c
+++ b/common/exf.c
@@ -90,7 +90,7 @@ file_add(
 		}
 
 	/* Allocate and initialize the FREF structure. */
-	CALLOC(sp, frp, FREF *, 1, sizeof(FREF));
+	CALLOC(sp, frp, 1, sizeof(FREF));
 	if (frp == NULL)
 		return (NULL);
 
@@ -160,7 +160,7 @@ file_init(
 	 *	Default recover mail file fd to -1.
 	 *	Set initial EXF flag bits.
 	 */
-	CALLOC_RET(sp, ep, EXF *, 1, sizeof(EXF));
+	CALLOC_RET(sp, ep, 1, sizeof(EXF));
 	ep->c_lno = ep->c_nlines = OOBLNO;
 	ep->rcv_fd = -1;
 	F_SET(ep, F_FIRSTMODIFY);

--- a/common/mark.c
+++ b/common/mark.c
@@ -175,7 +175,7 @@ mark_set(
 	 */
 	lmp = mark_find(sp, key);
 	if (lmp == NULL || lmp->name != key) {
-		MALLOC_RET(sp, lmt, LMARK *, sizeof(LMARK));
+		MALLOC_RET(sp, lmt, sizeof(LMARK));
 		if (lmp == NULL) {
 			SLIST_INSERT_HEAD(sp->ep->marks, lmt, q);
 		} else

--- a/common/mem.h
+++ b/common/mem.h
@@ -148,45 +148,38 @@
 
 /*
  * Malloc a buffer, casting the return pointer.  Various versions.
- *
- * !!!
- * The cast should be unnecessary, malloc(3) and friends return void *'s,
- * which is all we need.  However, some systems that nvi needs to run on
- * don't do it right yet, resulting in the compiler printing out roughly
- * a million warnings.  After awhile, it seemed easier to put the casts
- * in instead of explaining it all the time.
  */
-#define	CALLOC(sp, p, cast, nmemb, size) {				\
-	if ((p = (cast)calloc(nmemb, size)) == NULL)			\
+#define	CALLOC(sp, p, nmemb, size) {					\
+	if ((p = calloc(nmemb, size)) == NULL)				\
 		msgq(sp, M_SYSERR, NULL);				\
 }
-#define	CALLOC_GOTO(sp, p, cast, nmemb, size) {				\
-	if ((p = (cast)calloc(nmemb, size)) == NULL)			\
+#define	CALLOC_GOTO(sp, p, nmemb, size) {				\
+	if ((p = calloc(nmemb, size)) == NULL)				\
 		goto alloc_err;						\
 }
-#define	CALLOC_NOMSG(sp, p, cast, nmemb, size) {			\
-	p = (cast)calloc(nmemb, size);					\
+#define	CALLOC_NOMSG(sp, p, nmemb, size) {				\
+	p = calloc(nmemb, size);					\
 }
-#define	CALLOC_RET(sp, p, cast, nmemb, size) {				\
-	if ((p = (cast)calloc(nmemb, size)) == NULL) {			\
+#define	CALLOC_RET(sp, p, nmemb, size) {				\
+	if ((p = calloc(nmemb, size)) == NULL) {			\
 		msgq(sp, M_SYSERR, NULL);				\
 		return (1);						\
 	}								\
 }
 
-#define	MALLOC(sp, p, cast, size) {					\
-	if ((p = (cast)malloc(size)) == NULL)				\
+#define	MALLOC(sp, p, size) {						\
+	if ((p = malloc(size)) == NULL)					\
 		msgq(sp, M_SYSERR, NULL);				\
 }
-#define	MALLOC_GOTO(sp, p, cast, size) {				\
-	if ((p = (cast)malloc(size)) == NULL)				\
+#define	MALLOC_GOTO(sp, p, size) {					\
+	if ((p = malloc(size)) == NULL)					\
 		goto alloc_err;						\
 }
-#define	MALLOC_NOMSG(sp, p, cast, size) {				\
-	p = (cast)malloc(size);						\
+#define	MALLOC_NOMSG(sp, p, size) {					\
+	p = malloc(size);						\
 }
-#define	MALLOC_RET(sp, p, cast, size) {					\
-	if ((p = (cast)malloc(size)) == NULL) {				\
+#define	MALLOC_RET(sp, p, size) {					\
+	if ((p = malloc(size)) == NULL) {				\
 		msgq(sp, M_SYSERR, NULL);				\
 		return (1);						\
 	}								\
@@ -198,9 +191,8 @@
  */
 #define	REALLOC(sp, p, cast, size) {					\
 	cast newp;							\
-	if ((newp = (cast)realloc(p, size)) == NULL) {			\
-		if (p != NULL)						\
-			free(p);					\
+	if ((newp = realloc(p, size)) == NULL) {			\
+		free(p);						\
 		msgq(sp, M_SYSERR, NULL);				\
 	}								\
 	p = newp;							\

--- a/common/recover.c
+++ b/common/recover.c
@@ -404,7 +404,7 @@ rcv_mailfile(
 		goto err;
 	}
 
-	MALLOC(sp, host, char *, hostmax + 1);
+	MALLOC(sp, host, hostmax + 1);
 	if (host == NULL)
 		goto err;
 	(void)gethostname(host, hostmax + 1);
@@ -948,7 +948,7 @@ rcv_dlnread(
 	len -= src - bp;
 
 	/* Memory looks like: "<data>\0<dtype>\0". */
-	MALLOC(sp, data, char *, dlen + len / 4 * 3 + 2);
+	MALLOC(sp, data, dlen + len / 4 * 3 + 2);
 	if (data == NULL)
 		goto err;
 	if ((xlen = (b64_pton(p + dlen + 1,

--- a/common/screen.c
+++ b/common/screen.c
@@ -44,7 +44,7 @@ screen_init(
 	size_t len;
 
 	*spp = NULL;
-	CALLOC_RET(orig, sp, SCR *, 1, sizeof(SCR));
+	CALLOC_RET(orig, sp, 1, sizeof(SCR));
 	*spp = sp;
 
 /* INITIALIZED AT SCREEN CREATE. */
@@ -94,7 +94,7 @@ screen_init(
 		sp->repl_len = orig->repl_len;
 		if (orig->newl_len) {
 			len = orig->newl_len * sizeof(size_t);
-			MALLOC(sp, sp->newl, size_t *, len);
+			MALLOC(sp, sp->newl, len);
 			if (sp->newl == NULL) {
 mem:				msgq(orig, M_SYSERR, NULL);
 				goto err;

--- a/common/seq.c
+++ b/common/seq.c
@@ -76,7 +76,7 @@ seq_set(
 	}
 
 	/* Allocate and initialize SEQ structure. */
-	CALLOC(sp, qp, SEQ *, 1, sizeof(SEQ));
+	CALLOC(sp, qp, 1, sizeof(SEQ));
 	if (qp == NULL) {
 		sv_errno = errno;
 		goto mem1;

--- a/common/util.c
+++ b/common/util.c
@@ -255,7 +255,7 @@ v_strdup(
 {
 	char *copy;
 
-	MALLOC(sp, copy, char *, len + 1);
+	MALLOC(sp, copy, len + 1);
 	if (copy == NULL)
 		return (NULL);
 	memcpy(copy, str, len);
@@ -276,7 +276,7 @@ v_wstrdup(SCR *sp,
 {
 	CHAR_T *copy;
 
-	MALLOC(sp, copy, CHAR_T *, (len + 1) * sizeof(CHAR_T));
+	MALLOC(sp, copy, (len + 1) * sizeof(CHAR_T));
 	if (copy == NULL)
 		return (NULL);
 	MEMCPY(copy, str, len);

--- a/ex/ex_args.c
+++ b/ex/ex_args.c
@@ -88,8 +88,7 @@ ex_next(SCR *sp, EXCMD *cmdp)
 		sp->cargv = NULL;
 
 		/* Create a new list. */
-		CALLOC_RET(sp,
-		    sp->argv, char **, cmdp->argc + 1, sizeof(char *));
+		CALLOC_RET(sp, sp->argv, cmdp->argc + 1, sizeof(char *));
 		for (ap = sp->argv,
 		    argv = cmdp->argv; argv[0]->len != 0; ++ap, ++argv) {
 			INT2CHAR(sp, argv[0]->bp, argv[0]->len, np, nlen);
@@ -311,7 +310,7 @@ ex_buildargv(SCR *sp, EXCMD *cmdp, char *name)
 	size_t nlen;
 
 	argc = cmdp == NULL ? 1 : cmdp->argc;
-	CALLOC(sp, s_argv, char **, argc + 1, sizeof(char *));
+	CALLOC(sp, s_argv, argc + 1, sizeof(char *));
 	if ((ap = s_argv) == NULL)
 		return (NULL);
 

--- a/ex/ex_argv.c
+++ b/ex/ex_argv.c
@@ -484,7 +484,7 @@ argv_alloc(SCR *sp, size_t len)
 
 	/* First argument. */
 	if (exp->args[off] == NULL) {
-		CALLOC(sp, exp->args[off], ARGS *, 1, sizeof(ARGS));
+		CALLOC(sp, exp->args[off], 1, sizeof(ARGS));
 		if (exp->args[off] == NULL)
 			goto mem;
 	}
@@ -507,7 +507,7 @@ mem:			msgq(sp, M_SYSERR, NULL);
 
 	/* Second argument. */
 	if (exp->args[++off] == NULL) {
-		CALLOC(sp, exp->args[off], ARGS *, 1, sizeof(ARGS));
+		CALLOC(sp, exp->args[off], 1, sizeof(ARGS));
 		if (exp->args[off] == NULL)
 			goto mem;
 	}

--- a/ex/ex_at.c
+++ b/ex/ex_at.c
@@ -82,9 +82,9 @@ ex_at(SCR *sp, EXCMD *cmdp)
 	 * the  range, continue to execute after a file/screen switch, which
 	 * means @ buffers are still useful in a multi-screen environment.
 	 */
-	CALLOC_RET(sp, ecp, EXCMD *, 1, sizeof(EXCMD));
+	CALLOC_RET(sp, ecp, 1, sizeof(EXCMD));
 	TAILQ_INIT(ecp->rq);
-	CALLOC_RET(sp, rp, RANGE *, 1, sizeof(RANGE));
+	CALLOC_RET(sp, rp, 1, sizeof(RANGE));
 	rp->start = cmdp->addr1.lno;
 	if (F_ISSET(cmdp, E_ADDR_DEF)) {
 		rp->stop = rp->start;
@@ -106,7 +106,7 @@ ex_at(SCR *sp, EXCMD *cmdp)
 	TAILQ_FOREACH_REVERSE(tp, cbp->textq, _texth, q)
 		len += tp->len + 1;
 
-	MALLOC_RET(sp, ecp->cp, CHAR_T *, len * 2 * sizeof(CHAR_T));
+	MALLOC_RET(sp, ecp->cp, len * 2 * sizeof(CHAR_T));
 	ecp->o_cp = ecp->cp;
 	ecp->o_clen = len;
 	ecp->cp[len] = '\0';

--- a/ex/ex_cscope.c
+++ b/ex/ex_cscope.c
@@ -261,7 +261,7 @@ cscope_add(SCR *sp, EXCMD *cmdp, CHAR_T *dname)
 
 	/* Allocate a cscope connection structure and initialize its fields. */
 	len = strlen(np);
-	CALLOC_RET(sp, csc, CSC *, 1, sizeof(CSC) + len);
+	CALLOC_RET(sp, csc, 1, sizeof(CSC) + len);
 	csc->dname = csc->buf;
 	csc->dlen = len;
 	memcpy(csc->dname, np, len);
@@ -321,7 +321,7 @@ get_paths(SCR *sp, CSC *csc)
 	if (stat(buf, &sb) == 0) {
 		/* Read in the CSCOPE_PATHS file. */
 		len = sb.st_size;
-		MALLOC_RET(sp, csc->pbuf, char *, len + 1);
+		MALLOC_RET(sp, csc->pbuf, len + 1);
 		if ((fd = open(buf, O_RDONLY, 0)) < 0 ||
 		    read(fd, csc->pbuf, len) != len) {
 			 msgq_str(sp, M_SYSERR, buf, "%s");
@@ -340,8 +340,7 @@ get_paths(SCR *sp, CSC *csc)
 				++nentries;
 
 		/* Build an array of pointers to the paths. */
-		CALLOC_GOTO(sp,
-		    csc->paths, char **, nentries + 1, sizeof(char **));
+		CALLOC_GOTO(sp, csc->paths, nentries + 1, sizeof(char **));
 		for (pathp = csc->paths, p = strtok(csc->pbuf, ":");
 		    p != NULL; p = strtok(NULL, ":"))
 			*pathp++ = p;
@@ -357,7 +356,7 @@ get_paths(SCR *sp, CSC *csc)
 		msgq(sp, M_SYSERR, NULL);
 		return (1);
 	}
-	CALLOC_GOTO(sp, csc->paths, char **, 2, sizeof(char *));
+	CALLOC_GOTO(sp, csc->paths, 2, sizeof(char *));
 	csc->paths[0] = csc->pbuf;
 	return (0);
 
@@ -483,11 +482,11 @@ cscope_find(SCR *sp, EXCMD *cmdp, CHAR_T *pattern)
 	rtqp = NULL;
 	if (TAILQ_EMPTY(exp->tq)) {
 		/* Initialize the `local context' tag queue structure. */
-		CALLOC_GOTO(sp, rtqp, TAGQ *, 1, sizeof(TAGQ));
+		CALLOC_GOTO(sp, rtqp, 1, sizeof(TAGQ));
 		TAILQ_INIT(rtqp->tagq);
 
 		/* Initialize and link in its tag structure. */
-		CALLOC_GOTO(sp, rtp, TAG *, 1, sizeof(TAG));
+		CALLOC_GOTO(sp, rtp, 1, sizeof(TAG));
 		TAILQ_INSERT_HEAD(rtqp->tagq, rtp, q);
 		rtqp->current = rtp;
 	}
@@ -652,7 +651,7 @@ usage:		(void)csc_help(sp, "find");
 		tlen = strlen(p);
 
 	/* Allocate and initialize the TAGQ structure. */
-	CALLOC(sp, tqp, TAGQ *, 1, sizeof(TAGQ) + tlen + 3);
+	CALLOC(sp, tqp, 1, sizeof(TAGQ) + tlen + 3);
 	if (tqp == NULL)
 		return (NULL);
 	TAILQ_INIT(tqp->tagq);
@@ -756,9 +755,8 @@ parse(SCR *sp, CSC *csc, TAGQ *tqp, int *matchesp)
 		 * Allocate and initialize a tag structure plus the variable
 		 * length cscope information that follows it.
 		 */
-		CALLOC_RET(sp, tp,
-		    TAG *, 1, sizeof(TAG) + dlen + 2 + nlen + 1 +
-		    (slen + 1) * sizeof(CHAR_T));
+		CALLOC_RET(sp, tp, 1,
+			   sizeof(TAG) + dlen + 2 + nlen + 1 + (slen + 1) * sizeof(CHAR_T));
 		tp->fname = (char *)tp->buf;
 		if (dlen == 1 && *dname == '.')
 			--dlen;

--- a/ex/ex_global.c
+++ b/ex/ex_global.c
@@ -157,7 +157,7 @@ usage:		ex_emsg(sp, cmdp->cmd->usage, EXM_USAGE);
 		return (1);
 
 	/* Get an EXCMD structure. */
-	CALLOC_RET(sp, ecp, EXCMD *, 1, sizeof(EXCMD));
+	CALLOC_RET(sp, ecp, 1, sizeof(EXCMD));
 	TAILQ_INIT(ecp->rq);
 
 	/*
@@ -172,7 +172,7 @@ usage:		ex_emsg(sp, cmdp->cmd->usage, EXM_USAGE);
 		len = 1;
 	}
 
-	MALLOC_RET(sp, ecp->cp, CHAR_T *, (len * 2) * sizeof(CHAR_T));
+	MALLOC_RET(sp, ecp->cp, (len * 2) * sizeof(CHAR_T));
 	ecp->o_cp = ecp->cp;
 	ecp->o_clen = len;
 	MEMCPY(ecp->cp + len, p, len);
@@ -234,7 +234,7 @@ usage:		ex_emsg(sp, cmdp->cmd->usage, EXM_USAGE);
 		}
 
 		/* Allocate a new range, and append it to the list. */
-		CALLOC(sp, rp, RANGE *, 1, sizeof(RANGE));
+		CALLOC(sp, rp, 1, sizeof(RANGE));
 		if (rp == NULL)
 			return (1);
 		rp->start = rp->stop = start;
@@ -298,7 +298,7 @@ ex_g_insdel(SCR *sp, lnop_t op, recno_t lno)
 					free(rp);
 				}
 			} else {
-				CALLOC_RET(sp, nrp, RANGE *, 1, sizeof(RANGE));
+				CALLOC_RET(sp, nrp, 1, sizeof(RANGE));
 				nrp->start = lno + 1;
 				nrp->stop = rp->stop + 1;
 				rp->stop = lno - 1;

--- a/ex/ex_init.c
+++ b/ex/ex_init.c
@@ -46,7 +46,7 @@ ex_screen_copy(SCR *orig, SCR *sp)
 	EX_PRIVATE *oexp, *nexp;
 
 	/* Create the private ex structure. */
-	CALLOC_RET(orig, nexp, EX_PRIVATE *, 1, sizeof(EX_PRIVATE));
+	CALLOC_RET(orig, nexp, 1, sizeof(EX_PRIVATE));
 	sp->ex_private = nexp;
 
 	/* Initialize queues. */
@@ -291,7 +291,7 @@ ex_run_str(SCR *sp, char *name, CHAR_T *str, size_t len, int ex_flags, int nocop
 
 	gp = sp->gp;
 	if (EXCMD_RUNNING(gp)) {
-		CALLOC_RET(sp, ecp, EXCMD *, 1, sizeof(EXCMD));
+		CALLOC_RET(sp, ecp, 1, sizeof(EXCMD));
 		SLIST_INSERT_HEAD(gp->ecq, ecp, q);
 	} else
 		ecp = &gp->excmd;

--- a/ex/ex_script.c
+++ b/ex/ex_script.c
@@ -93,7 +93,7 @@ sscr_init(SCR *sp)
 	if (opts_empty(sp, O_SHELL, 0))
 		return (1);
 
-	MALLOC_RET(sp, sc, SCRIPT *, sizeof(SCRIPT));
+	MALLOC_RET(sp, sc, sizeof(SCRIPT));
 	sp->script = sc;
 	sc->sh_prompt = NULL;
 	sc->sh_prompt_len = 0;
@@ -525,7 +525,7 @@ sscr_setprompt(SCR *sp, char *buf, size_t len)
 	sc = sp->script;
 	if (sc->sh_prompt)
 		free(sc->sh_prompt);
-	MALLOC(sp, sc->sh_prompt, char *, len + 1);
+	MALLOC(sp, sc->sh_prompt, len + 1);
 	if (sc->sh_prompt == NULL) {
 		sscr_end(sp);
 		return (1);

--- a/ex/ex_source.c
+++ b/ex/ex_source.c
@@ -65,7 +65,7 @@ ex_source(SCR *sp, EXCMD *cmdp)
 		goto err;
 	}
 
-	MALLOC(sp, bp, char *, (size_t)sb.st_size + 1);
+	MALLOC(sp, bp, (size_t)sb.st_size + 1);
 	if (bp == NULL) {
 		(void)close(fd);
 		return (1);

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -232,7 +232,7 @@ tilde:				++p;
 		if ((sp->repl_len = len) != 0) {
 			if (sp->repl != NULL)
 				free(sp->repl);
-			MALLOC(sp, sp->repl, CHAR_T *, len * sizeof(CHAR_T));
+			MALLOC(sp, sp->repl, len * sizeof(CHAR_T));
 			if (sp->repl == NULL) {
 				FREE_SPACEW(sp, bp, blen);
 				return (1);
@@ -954,7 +954,7 @@ re_compile(SCR *sp, CHAR_T *ptrn, size_t plen, CHAR_T **ptrnp, size_t *lenp, reg
 		 * Regcomp isn't 8-bit clean, so the pattern is nul-terminated
 		 * for now.  There's just no other solution.  
 		 */
-		MALLOC(sp, *ptrnp, CHAR_T *, (plen + 1) * sizeof(CHAR_T));
+		MALLOC(sp, *ptrnp, (plen + 1) * sizeof(CHAR_T));
 		if (*ptrnp != NULL) {
 			MEMCPY(*ptrnp, ptrn, plen);
 			(*ptrnp)[plen] = '\0';
@@ -1289,7 +1289,7 @@ re_error(SCR *sp, int errcode, regex_t *preg)
 	char *oe;
 
 	s = regerror(errcode, preg, "", 0);
-	MALLOC(sp, oe, char *, s);
+	MALLOC(sp, oe, s);
 	if (oe != NULL) {
 		(void)regerror(errcode, preg, oe, s);
 		msgq(sp, M_ERR, "RE error: %s", oe);

--- a/ex/ex_tag.c
+++ b/ex/ex_tag.c
@@ -590,7 +590,7 @@ tagf_copy(SCR *sp, TAGF *otfp, TAGF **tfpp)
 {
 	TAGF *tfp;
 
-	MALLOC_RET(sp, tfp, TAGF *, sizeof(TAGF));
+	MALLOC_RET(sp, tfp, sizeof(TAGF));
 	*tfp = *otfp;
 
 	/* XXX: Allocate as part of the TAGF structure!!! */
@@ -614,7 +614,7 @@ tagq_copy(SCR *sp, TAGQ *otqp, TAGQ **tqpp)
 	len = sizeof(TAGQ);
 	if (otqp->tag != NULL)
 		len += otqp->tlen + 1;
-	MALLOC_RET(sp, tqp, TAGQ *, len);
+	MALLOC_RET(sp, tqp, len);
 	memcpy(tqp, otqp, len);
 
 	TAILQ_INIT(tqp->tagq);
@@ -643,7 +643,7 @@ tag_copy(SCR *sp, TAG *otp, TAG **tpp)
 		len += otp->slen + 1;
 	if (otp->msg != NULL)
 		len += otp->mlen + 1;
-	MALLOC_RET(sp, tp, TAG *, len);
+	MALLOC_RET(sp, tp, len);
 	memcpy(tp, otp, len);
 
 	if (otp->fname != NULL)
@@ -727,11 +727,11 @@ tagq_push(SCR *sp, TAGQ *tqp, int new_screen, int force)
 	rtqp = NULL;
 	if (TAILQ_EMPTY(exp->tq)) {
 		/* Initialize the `local context' tag queue structure. */
-		CALLOC_GOTO(sp, rtqp, TAGQ *, 1, sizeof(TAGQ));
+		CALLOC_GOTO(sp, rtqp, 1, sizeof(TAGQ));
 		TAILQ_INIT(rtqp->tagq);
 
 		/* Initialize and link in its tag structure. */
-		CALLOC_GOTO(sp, rtp, TAG *, 1, sizeof(TAG));
+		CALLOC_GOTO(sp, rtp, 1, sizeof(TAG));
 		TAILQ_INSERT_HEAD(rtqp->tagq, rtp, q);
 		rtqp->current = rtp;
 	}
@@ -858,8 +858,8 @@ ex_tagf_alloc(SCR *sp, char *str)
 	for (p = t = str;; ++p) {
 		if (*p == '\0' || cmdskip(*p)) {
 			if ((len = p - t)) {
-				MALLOC_RET(sp, tfp, TAGF *, sizeof(TAGF));
-				MALLOC(sp, tfp->name, char *, len + 1);
+				MALLOC_RET(sp, tfp, sizeof(TAGF));
+				MALLOC(sp, tfp->name, len + 1);
 				if (tfp->name == NULL) {
 					free(tfp);
 					return (1);
@@ -985,7 +985,7 @@ ctag_slist(SCR *sp, CHAR_T *tag)
 	/* Allocate and initialize the tag queue structure. */
 	INT2CHAR(sp, tag, STRLEN(tag) + 1, np, nlen);
 	len = nlen - 1;
-	CALLOC_GOTO(sp, tqp, TAGQ *, 1, sizeof(TAGQ) + len + 1);
+	CALLOC_GOTO(sp, tqp, 1, sizeof(TAGQ) + len + 1);
 	TAILQ_INIT(tqp->tagq);
 	tqp->tag = tqp->buf;
 	memcpy(tqp->tag, np, (tqp->tlen = len) + 1);
@@ -1125,9 +1125,8 @@ corrupt:		p = msg_print(sp, tname, &nf1);
 		/* Resolve the file name. */
 		ctag_file(sp, tfp, name, &dname, &dlen);
 
-		CALLOC_GOTO(sp, tp,
-		    TAG *, 1, sizeof(TAG) + dlen + 2 + nlen + 1 + 
-		    (slen + 1) * sizeof(CHAR_T));
+		CALLOC_GOTO(sp, tp, 1,
+			    sizeof(TAG) + dlen + 2 + nlen + 1 + (slen + 1) * sizeof(CHAR_T));
 		tp->fname = (char *)tp->buf;
 		if (dlen == 1 && *dname == '.')
 			--dlen;

--- a/vi/v_init.c
+++ b/vi/v_init.c
@@ -39,7 +39,7 @@ v_screen_copy(SCR *orig, SCR *sp)
 	VI_PRIVATE *ovip, *nvip;
 
 	/* Create the private vi structure. */
-	CALLOC_RET(orig, nvip, VI_PRIVATE *, 1, sizeof(VI_PRIVATE));
+	CALLOC_RET(orig, nvip, 1, sizeof(VI_PRIVATE));
 	sp->vi_private = nvip;
 
 	/* Invalidate the line size cache. */
@@ -52,7 +52,7 @@ v_screen_copy(SCR *orig, SCR *sp)
 
 		/* User can replay the last input, but nothing else. */
 		if (ovip->rep_len != 0) {
-			MALLOC_RET(orig, nvip->rep, EVENT *, ovip->rep_len);
+			MALLOC_RET(orig, nvip->rep, ovip->rep_len);
 			memmove(nvip->rep, ovip->rep, ovip->rep_len);
 			nvip->rep_len = ovip->rep_len;
 		}

--- a/vi/v_match.c
+++ b/vi/v_match.c
@@ -164,7 +164,7 @@ v_buildmcs(SCR *sp, char *str)
 
 	if (*mp != NULL)
 		free(*mp);
-	MALLOC(sp, *mp, CHAR_T *, len * sizeof(CHAR_T));
+	MALLOC(sp, *mp, len * sizeof(CHAR_T));
 	if (*mp == NULL)
 		return (1);
 #ifdef USE_WIDECHAR

--- a/vi/v_paragraph.c
+++ b/vi/v_paragraph.c
@@ -325,7 +325,7 @@ v_buildps(SCR *sp, char *p_p, char *s_p)
 	if (p_len == 0 && s_len == 0)
 		return (0);
 
-	MALLOC_RET(sp, p, char *, p_len + s_len + 1);
+	MALLOC_RET(sp, p, p_len + s_len + 1);
 
 	vip = VIP(sp);
 	if (vip->ps != NULL)

--- a/vi/vi.c
+++ b/vi/vi.c
@@ -970,7 +970,7 @@ v_init(SCR *sp)
 	sp->roff = sp->coff = 0;
 
 	/* Create a screen map. */
-	CALLOC_RET(sp, HMAP, SMAP *, SIZE_HMAP(sp), sizeof(SMAP));
+	CALLOC_RET(sp, HMAP, SIZE_HMAP(sp), sizeof(SMAP));
 	TMAP = HMAP + (sp->t_rows - 1);
 	HMAP->lno = sp->lno;
 	HMAP->coff = 0;

--- a/vi/vs_msg.c
+++ b/vi/vs_msg.c
@@ -875,8 +875,8 @@ vs_msgsave(SCR *sp, mtype_t mt, char *p, size_t len)
 	 * allocate memory here, we're genuinely screwed, dump the message
 	 * to stderr in the (probably) vain hope that someone will see it.
 	 */
-	CALLOC_GOTO(sp, mp_n, MSGS *, 1, sizeof(MSGS));
-	MALLOC_GOTO(sp, mp_n->buf, char *, len);
+	CALLOC_GOTO(sp, mp_n, 1, sizeof(MSGS));
+	MALLOC_GOTO(sp, mp_n->buf, len);
 
 	memmove(mp_n->buf, p, len);
 	mp_n->len = len;

--- a/vi/vs_split.c
+++ b/vi/vs_split.c
@@ -64,7 +64,7 @@ vs_split(
 	vs_resolve(sp, NULL, 1);
 
 	/* Get a new screen map. */
-	CALLOC(sp, _HMAP(new), SMAP *, SIZE_HMAP(sp), sizeof(SMAP));
+	CALLOC(sp, _HMAP(new), SIZE_HMAP(sp), sizeof(SMAP));
 	if (_HMAP(new) == NULL)
 		return (1);
 	_HMAP(new)->lno = sp->lno;
@@ -224,7 +224,7 @@ vs_vsplit(SCR *sp, SCR *new)
 	vs_resolve(sp, NULL, 1);
 
 	/* Get a new screen map. */
-	CALLOC(sp, _HMAP(new), SMAP *, SIZE_HMAP(sp), sizeof(SMAP));
+	CALLOC(sp, _HMAP(new), SIZE_HMAP(sp), sizeof(SMAP));
 	if (_HMAP(new) == NULL)
 		return (1);
 	_HMAP(new)->lno = sp->lno;
@@ -758,7 +758,7 @@ vs_swap(SCR *sp, SCR **nspp, char *name)
 	nsp->defscroll = nsp->t_maxrows / 2;
 
 	/* Allocate a new screen map. */
-	CALLOC_RET(nsp, _HMAP(nsp), SMAP *, SIZE_HMAP(nsp), sizeof(SMAP));
+	CALLOC_RET(nsp, _HMAP(nsp), SIZE_HMAP(nsp), sizeof(SMAP));
 	_TMAP(nsp) = _HMAP(nsp) + (nsp->t_rows - 1);
 
 	/* Fill the map. */


### PR DESCRIPTION
As the removed comment notes, it was sometimes necessary long-ago to
cast allocations. This is no longer the case, but nvi2's allocation
macros still take type parameters. We've already removed them in
OpenBSD's vi.

This commit also removes a needless NULL-check before free() in
REALLOC(). POSIX specifies that free() is NULL-safe, and all modern
platforms conform to this.