### PR TITLE
Only pass unsigned chars to ctype functions

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -202,12 +202,12 @@ retry:		FREE_SPACE(sp, bp, blen);
 		if (*p == '\0')
 			break;
 		++p;
-		if (!isdigit(*p)) {
+		if (!isdigit((u_char)*p)) {
 			if (*p == '%')
 				++p;
 			continue;
 		}
-		for (u = p; *++p != '\0' && isdigit(*p););
+		for (u = p; *++p != '\0' && isdigit((u_char)*p););
 		if (*p != '$')
 			continue;
 
@@ -839,8 +839,9 @@ msg_cat(
 	 * If it's not a catalog message, i.e. has doesn't have a leading
 	 * number and '|' symbol, we're done.
 	 */
-	if (isdigit(str[0]) &&
-	    isdigit(str[1]) && isdigit(str[2]) && str[3] == '|') {
+	if (isdigit((u_char)str[0]) &&
+	    isdigit((u_char)str[1]) &&
+	    isdigit((u_char)str[2]) && str[3] == '|') {
 		msgno = atoi(str);
 		str = &str[4];
 

--- a/common/util.c
+++ b/common/util.c
@@ -212,8 +212,8 @@ quote(char *str)
 			n++;
 		if (unsafe)
 			continue;
-		if (isascii(*p)) {
-			if (isalnum(*p))
+		if (isascii((u_char)*p)) {
+			if (isalnum((u_char)*p))
 				continue;
 			switch (*p) {
 			case '%': case '+': case ',': case '-': case '.':

--- a/ex/ex_usage.c
+++ b/ex/ex_usage.c
@@ -170,7 +170,8 @@ nokey:			(void)ex_printf(sp,
 		else
 			(void)ex_printf(sp,
 			    "  Key:%s%s\nUsage: %s\n",
-			    isblank(*kp->help) ? "" : " ", kp->help, kp->usage);
+			    isblank((u_char)*kp->help) ? "" : " ",
+			    kp->help, kp->usage);
 		break;
 	case 0:
 		for (key = 0; key <= MAXVIKEY && !INTERRUPTED(sp); ++key) {

--- a/vi/vs_msg.c
+++ b/vi/vs_msg.c
@@ -352,16 +352,16 @@ vs_msg(SCR *sp, mtype_t mtype, char *line, size_t len)
 		}
 	vip->mtype = mtype;
 	for (s = line;; s = t) {
-		for (; len > 0 && isblank(*s); --len, ++s);
+		for (; len > 0 && isblank((u_char)*s); --len, ++s);
 		if (len == 0)
 			break;
 		if (len + vip->lcontinue > maxcols) {
 			for (e = s + (maxcols - vip->lcontinue);
-			    e > s && !isblank(*e); --e);
+			    e > s && !isblank((u_char)*e); --e);
 			if (e == s)
 				 e = t = s + (maxcols - vip->lcontinue);
 			else
-				for (t = e; isblank(e[-1]); --e);
+				for (t = e; isblank((u_char)e[-1]); --e);
 		} else
 			e = t = s + len;
 


### PR DESCRIPTION
Passing a signed char to a ctype function is undefined behavior if it's
\>127. It's not a serious issue, but it's a worthwhile correctness fix.
Here's the CERT entry if you're interested:

https://www.securecoding.cert.org/confluence/x/fAs