### PR TITLE
Remove perr(), a clone of the stdlib's err()

### DIFF
--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -17,6 +17,7 @@ static const char sccsid[] = "$Id: cl_main.c,v 10.56 2015/04/05 06:20:53 zy Exp 
 #include <sys/queue.h>
 
 #include <bitstring.h>
+#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -39,7 +40,6 @@ sigset_t __sigblockset;				/* GLOBAL: Blocked signals. */
 static void	   cl_func_std(GS *);
 static CL_PRIVATE *cl_init(GS *);
 static GS	  *gs_init(char *);
-static void	   perr(char *, char *);
 static int	   setsig(int, struct sigaction *, void (*)(int));
 static void	   sig_end(GS *);
 static void	   term_init(char *, char *);
@@ -98,7 +98,7 @@ main(int argc, char *argv[])
 	/* Add the terminal type to the global structure. */
 	if ((OG_D_STR(gp, GO_TERM) =
 	    OG_STR(gp, GO_TERM) = strdup(ttype)) == NULL)
-		perr(gp->progname, NULL);
+		err(1, NULL);
 
 	/* Figure out how big the screen is. */
 	if (cl_ssize(NULL, 0, &rows, &cols, NULL))
@@ -174,7 +174,7 @@ gs_init(char *name)
 	/* Allocate the global structure. */
 	CALLOC_NOMSG(NULL, gp, GS *, 1, sizeof(GS));
 	if (gp == NULL)
-		perr(name, NULL);
+		err(1, NULL);
 
 	gp->progname = name;
 	return (gp);
@@ -193,7 +193,7 @@ cl_init(GS *gp)
 	/* Allocate the CL private structure. */
 	CALLOC_NOMSG(NULL, clp, CL_PRIVATE *, 1, sizeof(CL_PRIVATE));
 	if (clp == NULL)
-		perr(gp->progname, NULL);
+		err(1, NULL);
 	gp->cl_private = clp;
 
 	/*
@@ -216,7 +216,7 @@ cl_init(GS *gp)
 			goto tcfail;
 	} else if ((fd = open(_PATH_TTY, O_RDONLY, 0)) != -1) {
 		if (tcgetattr(fd, &clp->orig) == -1) {
-tcfail:			perr(gp->progname, "tcgetattr");
+tcfail:			err(1, "tcgetattr");
 			exit (1);
 		}
 		(void)close(fd);
@@ -315,7 +315,7 @@ sig_init(GS *gp, SCR *sp)
 		    setsig(SIGWINCH, &clp->oact[INDX_WINCH], h_winch)
 #endif
 		    ) {
-			perr(gp->progname, NULL);
+			err(1, NULL);
 			return (1);
 		}
 	} else
@@ -405,18 +405,4 @@ cl_func_std(GS *gp)
 	gp->scr_split = cl_split;
 	gp->scr_suspend = cl_suspend;
 	gp->scr_usage = cl_usage;
-}
-
-/*
- * perr --
- *	Print system error.
- */
-static void
-perr(char *name, char *msg)
-{
-	(void)fprintf(stderr, "%s:", name);
-	if (msg != NULL)
-		(void)fprintf(stderr, "%s:", msg);
-	(void)fprintf(stderr, "%s\n", strerror(errno));
-	exit(1);
 }


### PR DESCRIPTION
From Martijn van Duren <martijn987@gmail.com>.