### PR TITLE
Fix backward sentence deletion

### DIFF
--- a/common/delete.c
+++ b/common/delete.c
@@ -94,14 +94,16 @@ del(
 	if (tm->lno == fm->lno) {
 		if (db_get(sp, fm->lno, DBG_FATAL, &p, &len))
 			return (1);
-		GET_SPACE_RETW(sp, bp, blen, len);
-		if (fm->cno != 0)
-			MEMCPY(bp, p, fm->cno);
-		MEMCPY(bp + fm->cno, p + (tm->cno + 1), 
-			len - (tm->cno + 1));
-		if (db_set(sp, fm->lno,
-		    bp, len - ((tm->cno - fm->cno) + 1)))
-			goto err;
+		if (len > 0) {
+			GET_SPACE_RETW(sp, bp, blen, len);
+			if (fm->cno != 0)
+				MEMCPY(bp, p, fm->cno);
+			MEMCPY(bp + fm->cno, p + (tm->cno + 1),
+				len - (tm->cno + 1));
+			if (db_set(sp, fm->lno,
+			    bp, len - ((tm->cno - fm->cno) + 1)))
+				goto err;
+		}
 		goto done;
 	}
 

--- a/vi/v_sentence.c
+++ b/vi/v_sentence.c
@@ -291,7 +291,7 @@ ret:			slno = cs.cs_lno;
 			 * we can end up where we started.  Fix it.
 			 */
 			if (vp->m_start.lno != cs.cs_lno ||
-			    vp->m_start.cno != cs.cs_cno)
+			    vp->m_start.cno  > cs.cs_cno)
 				goto okret;
 
 			/*


### PR DESCRIPTION
- prevent ( from moving the cursor forwards
  (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=193498)
- guard against deletion within a line where size is negative