### PR TITLE
Remove a bzero alias

### DIFF
--- a/common/conv.c
+++ b/common/conv.c
@@ -118,7 +118,7 @@ default_char2int(SCR *sp, const char * str, ssize_t len, CONVWIN *cw,
 	size_t left = len;
 	int error = 1;
 
-	BZERO(&mbs, 1);
+	memset(&mbs, 0, sizeof(mbs));
 	BINC_RETW(NULL, *tostr, *blen, nlen);
 
 #ifdef USE_ICONV
@@ -245,7 +245,7 @@ default_int2char(SCR *sp, const CHAR_T * str, ssize_t len, CONVWIN *cw,
 #endif
 
 
-	BZERO(&mbs, 1);
+	memset(&mbs, 0, sizeof(mbs));
 	BINC_RETC(NULL, *tostr, *blen, nlen);
 	dst = *tostr; buflen = *blen;
 

--- a/common/mem.h
+++ b/common/mem.h
@@ -199,11 +199,10 @@
 }
 
 /*
- * Versions of bcopy(3) and bzero(3) that use the size of the
+ * A versions of bcopy(3) that uses the size of the
  * initial pointer to figure out how much memory to manipulate.
  */
 #define	BCOPY(p, t, len)	bcopy(p, t, (len) * sizeof(*(p)))
-#define	BZERO(p, len)		bzero(p, (len) * sizeof(*(p)))
 
 /* 
  * p2roundup --


### PR DESCRIPTION
I replaced it with memset rather than bzero. Most projects prefer memset
these days because it's standard while bzero isn't, and because there's
no significant benefit of using bzero.