### PR TITLE
Remove NULL-checks before free()

### DIFF
--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -147,8 +147,7 @@ main(int argc, char *argv[])
 
 	/* Free the global and CL private areas. */
 #if defined(DEBUG) || defined(PURIFY)
-	if (clp->oname != NULL)
-		free(clp->oname);
+	free(clp->oname);
 	free(clp);
 	free(OG_STR(gp, GO_TERM));
 	free(gp);

--- a/cl/cl_screen.c
+++ b/cl/cl_screen.c
@@ -450,14 +450,10 @@ cl_ex_init(SCR *sp)
 
 	/* Enter_standout_mode and exit_standout_mode are paired. */
 	if (clp->smso == NULL || clp->rmso == NULL) {
-		if (clp->smso != NULL) {
-			free(clp->smso);
-			clp->smso = NULL;
-		}
-		if (clp->rmso != NULL) {
-			free(clp->rmso);
-			clp->rmso = NULL;
-		}
+		free(clp->smso);
+		clp->smso = NULL;
+		free(clp->rmso);
+		clp->rmso = NULL;
 	}
 
 	/*
@@ -539,26 +535,16 @@ cl_getcap(SCR *sp, char *name, char **elementp)
 static void
 cl_freecap(CL_PRIVATE *clp)
 {
-	if (clp->el != NULL) {
-		free(clp->el);
-		clp->el = NULL;
-	}
-	if (clp->cup != NULL) {
-		free(clp->cup);
-		clp->cup = NULL;
-	}
-	if (clp->cuu1 != NULL) {
-		free(clp->cuu1);
-		clp->cuu1 = NULL;
-	}
-	if (clp->rmso != NULL) {
-		free(clp->rmso);
-		clp->rmso = NULL;
-	}
-	if (clp->smso != NULL) {
-		free(clp->smso);
-		clp->smso = NULL;
-	}
+	free(clp->el);
+	clp->el = NULL;
+	free(clp->cup);
+	clp->cup = NULL;
+	free(clp->cuu1);
+	clp->cuu1 = NULL;
+	free(clp->rmso);
+	clp->rmso = NULL;
+	free(clp->smso);
+	clp->smso = NULL;
 	/* Required by libcursesw :) */
 	if (clp->cw.bp1.c != NULL) {
 		free(clp->cw.bp1.c);

--- a/common/conv.c
+++ b/common/conv.c
@@ -464,7 +464,6 @@ conv_end(SCR *sp)
 	for (i = 0; i <= IC_IE_TO_UTF16; ++i)
 		if (sp->conv.id[i] != (iconv_t)-1)
 			iconv_close(sp->conv.id[i]);
-	if (sp->cw.bp1.c != NULL)
-		free(sp->cw.bp1.c);
+	free(sp->cw.bp1.c);
 #endif
 }

--- a/common/cut.c
+++ b/common/cut.c
@@ -331,7 +331,6 @@ text_lfree(TEXTH *headp)
 void
 text_free(TEXT *tp)
 {
-	if (tp->lb != NULL)
-		free(tp->lb);
+	free(tp->lb);
 	free(tp);
 }

--- a/common/exf.c
+++ b/common/exf.c
@@ -78,8 +78,7 @@ file_add(SCR *sp, char *name)
 		TAILQ_FOREACH_SAFE(frp, gp->frefq, q, tfrp) {
 			if (frp->name == NULL) {
 				TAILQ_REMOVE(gp->frefq, frp, q);
-				if (frp->name != NULL)
-					free(frp->name);
+				free(frp->name);
 				free(frp);
 				continue;
 			}
@@ -412,10 +411,8 @@ file_init(SCR *sp, FREF *frp, char *rcv_name, int flags)
 
 	return (0);
 
-err:	if (frp->name != NULL) {
-		free(frp->name);
-		frp->name = NULL;
-	}
+err:	free(frp->name);
+	frp->name = NULL;
 	if (frp->tname != NULL) {
 		(void)unlink(frp->tname);
 		free(frp->tname);
@@ -424,10 +421,8 @@ err:	if (frp->name != NULL) {
 
 oerr:	if (F_ISSET(ep, F_RCV_ON))
 		(void)unlink(ep->rcv_path);
-	if (ep->rcv_path != NULL) {
-		free(ep->rcv_path);
-		ep->rcv_path = NULL;
-	}
+	free(ep->rcv_path);
+	ep->rcv_path = NULL;
 	if (ep->db != NULL)
 		(void)ep->db->close(ep->db);
 	free(ep);
@@ -668,8 +663,7 @@ file_end(SCR *sp, EXF *ep, int force)
 		frp->tname = NULL;
 		if (F_ISSET(frp, FR_TMPFILE)) {
 			TAILQ_REMOVE(sp->gp->frefq, frp, q);
-			if (frp->name != NULL)
-				free(frp->name);
+			free(frp->name);
 			free(frp);
 		}
 		sp->frp = NULL;
@@ -711,10 +705,8 @@ file_end(SCR *sp, EXF *ep, int force)
 	}
 	if (ep->rcv_fd != -1)
 		(void)close(ep->rcv_fd);
-	if (ep->rcv_path != NULL)
-		free(ep->rcv_path);
-	if (ep->rcv_mpath != NULL)
-		free(ep->rcv_mpath);
+	free(ep->rcv_path);
+	free(ep->rcv_mpath);
 	if (ep->c_blen > 0)
 		free(ep->c_lp);
 
@@ -1180,8 +1172,7 @@ err:	if (rfd != -1)
 	}
 	if (estr)
 		msgq_str(sp, M_SYSERR, estr, "%s");
-	if (d != NULL)
-		free(d);
+	free(d);
 	if (bp != NULL)
 		FREE_SPACE(sp, bp, blen);
 	return (1);
@@ -1448,8 +1439,7 @@ file_aw(SCR *sp, int flags)
 void
 set_alt_name(SCR *sp, char *name)
 {
-	if (sp->alt_name != NULL)
-		free(sp->alt_name);
+	free(sp->alt_name);
 	if (name == NULL)
 		sp->alt_name = NULL;
 	else if ((sp->alt_name = strdup(name)) == NULL)

--- a/common/key.c
+++ b/common/key.c
@@ -793,8 +793,7 @@ v_event_err(SCR *sp, EVENT *evp)
 	}
 
 	/* Free any allocated memory. */
-	if (evp->e_asp != NULL)
-		free(evp->e_asp);
+	free(evp->e_asp);
 }
 
 /*

--- a/common/log.c
+++ b/common/log.c
@@ -138,10 +138,8 @@ log_end(SCR *sp, EXF *ep)
 		(void)(ep->log->close)(ep->log);
 		ep->log = NULL;
 	}
-	if (ep->l_lp != NULL) {
-		free(ep->l_lp);
-		ep->l_lp = NULL;
-	}
+	free(ep->l_lp);
+	ep->l_lp = NULL;
 	ep->l_len = 0;
 	ep->l_cursor.lno = 1;		/* XXX Any valid recno. */
 	ep->l_cursor.cno = 0;

--- a/common/main.c
+++ b/common/main.c
@@ -444,17 +444,14 @@ v_end(gp)
 		/* Free FREF's. */
 		while ((frp = TAILQ_FIRST(gp->frefq)) != NULL) {
 			TAILQ_REMOVE(gp->frefq, frp, q);
-			if (frp->name != NULL)
-				free(frp->name);
-			if (frp->tname != NULL)
-				free(frp->tname);
+			free(frp->name);
+			free(frp->tname);
 			free(frp);
 		}
 	}
 
 	/* Free key input queue. */
-	if (gp->i_event != NULL)
-		free(gp->i_event);
+	free(gp->i_event);
 
 	/* Free cut buffers. */
 	cut_close(gp);
@@ -491,8 +488,7 @@ v_end(gp)
 
 #if defined(DEBUG) || defined(PURIFY)
 	/* Free any temporary space. */
-	if (gp->tmp_bp != NULL)
-		free(gp->tmp_bp);
+	free(gp->tmp_bp);
 
 #if defined(DEBUG)
 	/* Close debugging file descriptor. */

--- a/common/options.c
+++ b/common/options.c
@@ -1153,9 +1153,7 @@ opts_free(SCR *sp)
 		if (optlist[cnt].type != OPT_STR ||
 		    F_ISSET(&sp->opts[cnt], OPT_GLOBAL))
 			continue;
-		if (O_STR(sp, cnt) != NULL)
-			free(O_STR(sp, cnt));
-		if (O_D_STR(sp, cnt) != NULL)
-			free(O_D_STR(sp, cnt));
+		free(O_STR(sp, cnt));
+		free(O_D_STR(sp, cnt));
 	}
 }

--- a/common/recover.c
+++ b/common/recover.c
@@ -586,10 +586,8 @@ rcv_list(SCR *sp)
 
 		/* Close, discarding lock. */
 next:		(void)fclose(fp);
-		if (file != NULL)
-			free(file);
-		if (path != NULL)
-			free(path);
+		free(file);
+		free(path);
 	}
 	if (found == 0)
 		(void)printf("%s: No files to recover\n", getprogname());

--- a/common/screen.c
+++ b/common/screen.c
@@ -169,22 +169,17 @@ screen_end(SCR *sp)
 		text_lfree(sp->tiq);
 
 	/* Free alternate file name. */
-	if (sp->alt_name != NULL)
-		free(sp->alt_name);
+	free(sp->alt_name);
 
 	/* Free up search information. */
-	if (sp->re != NULL)
-		free(sp->re);
+	free(sp->re);
 	if (F_ISSET(sp, SC_RE_SEARCH))
 		regfree(&sp->re_c);
-	if (sp->subre != NULL)
-		free(sp->subre);
+	free(sp->subre);
 	if (F_ISSET(sp, SC_RE_SUBST))
 		regfree(&sp->subre_c);
-	if (sp->repl != NULL)
-		free(sp->repl);
-	if (sp->newl != NULL)
-		free(sp->newl);
+	free(sp->repl);
+	free(sp->newl);
 
 	/* Free the iconv environment */
 	conv_end(sp);

--- a/common/seq.c
+++ b/common/seq.c
@@ -60,8 +60,7 @@ seq_set(SCR *sp, CHAR_T *name, size_t nlen, CHAR_T *input, size_t ilen,
 			sv_errno = errno;
 			goto mem1;
 		}
-		if (qp->output != NULL)
-			free(qp->output);
+		free(qp->output);
 		qp->olen = olen;
 		qp->output = p;
 		return (0);
@@ -97,8 +96,7 @@ seq_set(SCR *sp, CHAR_T *name, size_t nlen, CHAR_T *input, size_t ilen,
 	} else if ((qp->output = v_wstrdup(sp, output, olen)) == NULL) {
 		sv_errno = errno;
 		free(qp->input);
-mem3:		if (qp->name != NULL)
-			free(qp->name);
+mem3:		free(qp->name);
 mem2:		free(qp);
 mem1:		errno = sv_errno;
 		msgq(sp, M_SYSERR, NULL);
@@ -165,12 +163,9 @@ seq_delete(SCR *sp, CHAR_T *input, size_t ilen, seq_t stype)
 int
 seq_free(SEQ *qp)
 {
-	if (qp->name != NULL)
-		free(qp->name);
-	if (qp->input != NULL)
-		free(qp->input);
-	if (qp->output != NULL)
-		free(qp->output);
+	free(qp->name);
+	free(qp->input);
+	free(qp->output);
 	free(qp);
 	return (0);
 }

--- a/ex/ex_bang.c
+++ b/ex/ex_bang.c
@@ -67,8 +67,7 @@ ex_bang(SCR *sp, EXCMD *cmdp)
 
 	/* Set the "last bang command" remembered value. */
 	exp = EXP(sp);
-	if (exp->lastbcomm != NULL)
-		free(exp->lastbcomm);
+	free(exp->lastbcomm);
 	if ((exp->lastbcomm = v_wstrdup(sp, ap->bp, ap->len)) == NULL) {
 		msgq(sp, M_SYSERR, NULL);
 		return (1);

--- a/ex/ex_cscope.c
+++ b/ex/ex_cscope.c
@@ -361,10 +361,8 @@ get_paths(SCR *sp, CSC *csc)
 	return (0);
 
 alloc_err:
-	if (csc->pbuf != NULL) {
-		free(csc->pbuf);
-		csc->pbuf = NULL;
-	}
+	free(csc->pbuf);
+	csc->pbuf = NULL;
 	return (1);
 }
 
@@ -496,8 +494,7 @@ cscope_find(SCR *sp, EXCMD *cmdp, CHAR_T *pattern)
 	np = strdup(np);
 	if ((tqp = create_cs_cmd(sp, np, &search)) == NULL)
 		goto err;
-	if (np != NULL)
-		free(np);
+	free(np);
 
 	/*
 	 * Stick the current context in a convenient place, we'll lose it
@@ -528,10 +525,8 @@ cscope_find(SCR *sp, EXCMD *cmdp, CHAR_T *pattern)
 
 	if (matches == 0) {
 		msgq(sp, M_INFO, "278|No matches for query");
-nomatch:	if (rtp != NULL)
-			free(rtp);
-		if (rtqp != NULL)
-			free(rtqp);
+nomatch:	free(rtp);
+		free(rtqp);
 		tagq_free(sp, tqp);
 		return (1);
 	}
@@ -587,12 +582,9 @@ nomatch:	if (rtp != NULL)
 
 err:
 alloc_err:
-	if (rtqp != NULL)
-		free(rtqp);
-	if (rtp != NULL)
-		free(rtp);
-	if (np != NULL)
-		free(np);
+	free(rtqp);
+	free(rtp);
+	free(np);
 	return (1);
 }
 
@@ -941,10 +933,8 @@ badno:		msgq(sp, M_ERR, "312|%d: no such cscope session", n);
 	(void)waitpid(csc->pid, &pstat, 0);
 
 	/* Discard cscope connection information. */
-	if (csc->pbuf != NULL)
-		free(csc->pbuf);
-	if (csc->paths != NULL)
-		free(csc->paths);
+	free(csc->pbuf);
+	free(csc->paths);
 	free(csc);
 	return (0);
 }

--- a/ex/ex_init.c
+++ b/ex/ex_init.c
@@ -94,14 +94,11 @@ ex_screen_end(SCR *sp)
 	if (argv_free(sp))
 		rval = 1;
 
-	if (exp->ibp != NULL)
-		free(exp->ibp);
+	free(exp->ibp);
 
-	if (exp->lastbcomm != NULL)
-		free(exp->lastbcomm);
+	free(exp->lastbcomm);
 
-	if (exp->ibcw.bp1.c != NULL)
-		free(exp->ibcw.bp1.c);
+	free(exp->ibcw.bp1.c);
 
 	if (ex_tag_free(sp))
 		rval = 1;

--- a/ex/ex_read.c
+++ b/ex/ex_read.c
@@ -112,8 +112,7 @@ ex_read(SCR *sp, EXCMD *cmdp)
 
 		/* Set the last bang command. */
 		exp = EXP(sp);
-		if (exp->lastbcomm != NULL)
-			free(exp->lastbcomm);
+		free(exp->lastbcomm);
 		if ((exp->lastbcomm =
 		    v_wstrdup(sp, cmdp->argv[argc]->bp,
 				cmdp->argv[argc]->len)) == NULL) {

--- a/ex/ex_script.c
+++ b/ex/ex_script.c
@@ -523,8 +523,7 @@ sscr_setprompt(SCR *sp, char *buf, size_t len)
 	SCRIPT *sc;
 
 	sc = sp->script;
-	if (sc->sh_prompt)
-		free(sc->sh_prompt);
+	free(sc->sh_prompt);
 	MALLOC(sp, sc->sh_prompt, len + 1);
 	if (sc->sh_prompt == NULL) {
 		sscr_end(sp);

--- a/ex/ex_source.c
+++ b/ex/ex_source.c
@@ -88,8 +88,7 @@ err:		msgq_str(sp, M_SYSERR, name, "%s");
 		msgq(sp, M_ERR, "323|Invalid input. Truncated.");
 	/* Put it on the ex queue. */
 	rc = ex_run_str(sp, np, wp, wlen - 1, 1, 0);
-	if (np != NULL)
-		free(np);
+	free(np);
 	free(bp);
 	return (rc);
 }

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -190,8 +190,7 @@ subagain:	return (ex_subagain(sp, cmdp));
 	if (p[0] == '\0' || p[0] == delim) {
 		if (p[0] == delim)
 			++p;
-		if (sp->repl != NULL)
-			free(sp->repl);
+		free(sp->repl);
 		sp->repl = NULL;
 		sp->repl_len = 0;
 	} else if (p[0] == '%' && (p[1] == '\0' || p[1] == delim))
@@ -230,8 +229,7 @@ tilde:				++p;
 			++len;
 		}
 		if ((sp->repl_len = len) != 0) {
-			if (sp->repl != NULL)
-				free(sp->repl);
+			free(sp->repl);
 			MALLOC(sp, sp->repl, len * sizeof(CHAR_T));
 			if (sp->repl == NULL) {
 				FREE_SPACEW(sp, bp, blen);
@@ -870,8 +868,7 @@ err:		rval = 1;
 
 	if (bp != NULL)
 		FREE_SPACEW(sp, bp, blen);
-	if (lb != NULL)
-		free(lb);
+	free(lb);
 	return (rval);
 }
 
@@ -940,10 +937,8 @@ re_compile(SCR *sp, CHAR_T *ptrn, size_t plen, CHAR_T **ptrnp, size_t *lenp, reg
 				return (1);
 
 		/* Discard previous pattern. */
-		if (*ptrnp != NULL) {
-			free(*ptrnp);
-			*ptrnp = NULL;
-		}
+		free(*ptrnp);
+		*ptrnp = NULL;
 		if (lenp != NULL)
 			*lenp = plen;
 

--- a/ex/ex_tag.c
+++ b/ex/ex_tag.c
@@ -98,8 +98,7 @@ ex_tag_push(SCR *sp, EXCMD *cmdp)
 	exp = EXP(sp);
 	switch (cmdp->argc) {
 	case 1:
-		if (exp->tag_last != NULL)
-			free(exp->tag_last);
+		free(exp->tag_last);
 
 		if ((exp->tag_last = v_wstrdup(sp, cmdp->argv[0]->bp,
 		    cmdp->argv[0]->len)) == NULL) {
@@ -802,10 +801,8 @@ tagq_push(SCR *sp, TAGQ *tqp, int new_screen, int force)
 
 err:
 alloc_err:
-	if (rtqp != NULL)
-		free(rtqp);
-	if (rtp != NULL)
-		free(rtp);
+	free(rtqp);
+	free(rtp);
 	tagq_free(sp, tqp);
 	return (1);
 }
@@ -896,8 +893,7 @@ ex_tag_free(SCR *sp)
 		tagq_free(sp, tqp);
 	while ((tfp = TAILQ_FIRST(exp->tagfq)) != NULL)
 		tagf_free(sp, tfp);
-	if (exp->tag_last != NULL)
-		free(exp->tag_last);
+	free(exp->tag_last);
 	return (0);
 }
 

--- a/regex/regcomp.c
+++ b/regex/regcomp.c
@@ -1236,8 +1236,7 @@ mcadd(struct parse *p, cset *cs, const char *cp)
 	cs->smultis += strlen(cp) + 1;
 	np = realloc(cs->multis, cs->smultis);
 	if (np == NULL) {
-		if (cs->multis)
-			free(cs->multis);
+		free(cs->multis);
 		cs->multis = NULL;
 		SETERROR(REG_ESPACE);
 		return;

--- a/regex/regfree.c
+++ b/regex/regfree.c
@@ -72,7 +72,6 @@ regfree(regex_t *preg)
 		free((char *)g->sets);
 	if (g->setbits != NULL)
 		free((char *)g->setbits);
-	if (g->must != NULL)
-		free(g->must);
+	free(g->must);
 	free((char *)g);
 }

--- a/vi/v_init.c
+++ b/vi/v_init.c
@@ -88,17 +88,12 @@ v_screen_end(SCR *sp)
 
 	if ((vip = VIP(sp)) == NULL)
 		return (0);
-	if (vip->keyw != NULL)
-		free(vip->keyw);
-	if (vip->rep != NULL)
-		free(vip->rep);
-	if (vip->mcs != NULL)
-		free(vip->mcs);
-	if (vip->ps != NULL)
-		free(vip->ps);
+	free(vip->keyw);
+	free(vip->rep);
+	free(vip->mcs);
+	free(vip->ps);
 
-	if (HMAP != NULL)
-		free(HMAP);
+	free(HMAP);
 
 	free(vip);
 	sp->vi_private = NULL;

--- a/vi/v_match.c
+++ b/vi/v_match.c
@@ -162,8 +162,7 @@ v_buildmcs(SCR *sp, char *str)
 	CHAR_T **mp = &VIP(sp)->mcs;
 	size_t len = strlen(str) + 1;
 
-	if (*mp != NULL)
-		free(*mp);
+	free(*mp);
 	MALLOC(sp, *mp, len * sizeof(CHAR_T));
 	if (*mp == NULL)
 		return (1);

--- a/vi/v_paragraph.c
+++ b/vi/v_paragraph.c
@@ -328,8 +328,7 @@ v_buildps(SCR *sp, char *p_p, char *s_p)
 	MALLOC_RET(sp, p, p_len + s_len + 1);
 
 	vip = VIP(sp);
-	if (vip->ps != NULL)
-		free(vip->ps);
+	free(vip->ps);
 
 	if (p_p != NULL)
 		memmove(p, p_p, p_len + 1);

--- a/vi/vi.c
+++ b/vi/vi.c
@@ -1007,10 +1007,8 @@ v_dtoh(SCR *sp)
 	/* Move all screens to the hidden queue, tossing screen maps. */
 	for (hidden = 0, gp = sp->gp;
 	    (tsp = TAILQ_FIRST(gp->dq)) != NULL; ++hidden) {
-		if (_HMAP(tsp) != NULL) {
-			free(_HMAP(tsp));
-			_HMAP(tsp) = NULL;
-		}
+		free(_HMAP(tsp));
+		_HMAP(tsp) = NULL;
 		TAILQ_REMOVE(gp->dq, tsp, q);
 		TAILQ_INSERT_TAIL(gp->hq, tsp, q);
 		/* XXXX Change if hidden screens per window */

--- a/vi/vs_msg.c
+++ b/vi/vs_msg.c
@@ -894,7 +894,6 @@ vs_msgsave(SCR *sp, mtype_t mt, char *p, size_t len)
 	return;
 
 alloc_err:
-	if (mp_n != NULL)
-		free(mp_n);
+	free(mp_n);
 	(void)fprintf(stderr, "%.*s\n", (int)len, p);
 }


### PR DESCRIPTION
free() has been specified as NULL-safe since C89. All modern systems and
almost all prehistoric ones have NULL-safe free implementations.
Removing this dead logic often makes code significantly more readable.