### PR TITLE
vi.1: Fix incorrect formatting

### DIFF
--- a/docs/man/vi.1
+++ b/docs/man/vi.1
@@ -981,7 +981,11 @@ command.
 .Cm ;\&
 .Xc
 Repeat the last character find
-.Pq i.e., the last .Cm F , f , T No or Cm t No command
+(i.e., the last
+.Cm F , f , T
+or
+.Cm t
+command)
 .Ar count
 times.
 .Pp


### PR DESCRIPTION
There was a literal `.Cm` appearing in mandoc(1)'s output:

```diff
+	      Repeat the last character find (i.e., the last .Cm F, f, T or t
-	      Repeat the last character find (i.e., the last F, f, T or t
	      command) count times.
```

Besides that, only the last command (`t`) was being bolded, while the
others were unformatted.