### PR TITLE
vi.1: prefer literal characters over roff(7) escape sequences

### DIFF
--- a/docs/man/vi.1
+++ b/docs/man/vi.1
@@ -353,7 +353,7 @@ matches the beginning of the word.
 .Sq \e>
 matches the end of the word.
 .It
-.Sq \(a~
+.Sq ~
 matches the replacement part of the last
 .Cm substitute
 command.
@@ -414,7 +414,7 @@ make the destination buffer character-oriented.
 .Cm j ,
 .Aq Cm control-M ,
 .Cm k ,
-.Cm \(aq ,
+.Cm \&' ,
 .Cm - ,
 .Cm G ,
 .Cm H ,
@@ -804,7 +804,7 @@ If
 .Ar count
 is specified, additionally move the cursor down
 .Ar count
-\(mi 1 lines.
+- 1 lines.
 .Pp
 .It Cm %
 Move to the
@@ -816,7 +816,7 @@ the one found at the cursor position or the closest to the right of it.
 Repeat the previous substitution command on the current line.
 .Pp
 .It Xo
-.Cm \(aq Ns Aq Ar character
+.Cm \&' Ns Aq Ar character
 .Xc
 .It Xo
 .Cm \` Ns Aq Ar character
@@ -826,7 +826,7 @@ Return to the cursor position marked by the character
 or, if
 .Ar character
 is
-.Sq \(aq
+.Sq \&'
 or
 .Sq \` ,
 to the position of the cursor before the last of the following commands:
@@ -834,7 +834,7 @@ to the position of the cursor before the last of the following commands:
 .Aq Cm control-T ,
 .Aq Cm control-] ,
 .Cm % ,
-.Cm \(aq ,
+.Cm \&' ,
 .Cm \` ,
 .Cm (\& ,
 .Cm )\& ,
@@ -1032,7 +1032,7 @@ If a
 .Ar count
 argument is given, the characters input are repeated
 .Ar count
-\(mi 1 times after input mode is exited.
+- 1 times after input mode is exited.
 .Pp
 .It Xo
 .Op Ar count
@@ -1099,7 +1099,7 @@ is not specified.
 .Xc
 Move to the screen line
 .Ar count
-\(mi 1 lines below the top of the screen.
+- 1 lines below the top of the screen.
 .Pp
 .It Xo
 .Op Ar count
@@ -1111,7 +1111,7 @@ If a
 argument is given,
 the characters input are repeated
 .Ar count
-\(mi 1 more times.
+- 1 more times.
 .Pp
 .It Xo
 .Op Ar count
@@ -1130,7 +1130,7 @@ It is set to one whitespace character otherwise.
 .Xc
 Move to the screen line
 .Ar count
-\(mi 1 lines above the bottom of the screen.
+- 1 lines above the bottom of the screen.
 .Pp
 .It Cm M
 Move to the screen line in the middle of the screen.
@@ -1145,7 +1145,7 @@ If a
 argument is given,
 the characters input are repeated
 .Ar count
-\(mi 1 more times.
+- 1 more times.
 .Pp
 .It Xo
 .Op Ar buffer
@@ -1175,7 +1175,7 @@ If a
 argument is given,
 the characters input are repeated
 .Ar count
-\(mi 1 more times upon exit from insert mode.
+- 1 more times upon exit from insert mode.
 .Pp
 .It Xo
 .Op Ar buffer
@@ -1272,7 +1272,7 @@ Move to the first non-blank character on the current line.
 .Xc
 Move down
 .Ar count
-\(mi 1 lines, to the first non-blank character.
+- 1 lines, to the first non-blank character.
 .Pp
 .It Xo
 .Op Ar count
@@ -1376,7 +1376,7 @@ If a
 argument is given,
 the characters input are repeated
 .Ar count
-\(mi 1 more times.
+- 1 more times.
 .Pp
 .It Xo
 .Op Ar buffer
@@ -2042,10 +2042,10 @@ The
 .Ar replace
 field may contain any of the following sequences:
 .Bl -tag -width Ds
-.It Sq \*(Am
+.It Sq &
 The text matched by
 .Ar pattern .
-.It Sq \(a~
+.It Sq ~
 The replacement part of the previous
 .Cm substitute
 command.
@@ -2055,9 +2055,9 @@ If this is the entire
 pattern, the replacement part of the previous
 .Cm substitute
 command.
-.It Sq \e Ns Ar \(sh
+.It Sq \e Ns Ar #
 Where
-.Sq Ar \(sh
+.Sq Ar #
 is an integer from 1 to 9, the text matched by the
 .Ar # Ns 'th subexpression in
 .Ar pattern .
@@ -2351,9 +2351,9 @@ Display lines in an unambiguous fashion.
 Attempt to get an exclusive lock on any file being edited, read or written.
 .It Cm magic Bq on
 When turned off, all regular expression characters except for
-.Sq \(ha
+.Sq ^
 and
-.Sq \(Do
+.Sq $
 are treated as ordinary characters.
 Preceding individual characters by
 .Sq \e
@@ -2453,7 +2453,7 @@ commands.
 Turns off all access to external programs.
 .It Cm shell , sh Bo environment variable Ev SHELL , or Pa /bin/sh Bc
 Select the shell used by the editor.
-.It Cm shellmeta Bq ~{[*?$\`\(aq\&"\e
+.It Cm shellmeta Bq ~{[*?$\`\&'\&"\e
 Set the meta characters checked to determine if file name expansion
 is necessary.
 .It Cm shiftwidth , sw Bq 8
@@ -2527,7 +2527,7 @@ if the file has been modified since it was last written, before a
 command.
 .It Xo
 .Cm window , w , wi
-.Bq environment variable Ev LINES No \(mi 1
+.Bq environment variable Ev LINES No - 1
 .Xc
 Set the window size for the screen.
 .It Cm windowname Bq off
@@ -2721,7 +2721,7 @@ The
 and
 .Nm vi
 utilities exit 0 on success,
-and \*(Gt0 if an error occurs.
+and >0 if an error occurs.
 .Sh SEE ALSO
 .Xr ctags 1 ,
 .Xr iconv 1 ,


### PR DESCRIPTION
The only change in the formatted output (by mandoc(1) in a terminal) is in the dashes, i.e., `\(mi)`. 
Besides the fact that such escape sequences generally have no effect on the generated output, they make it harder to read the document while offering negligible benefit; @bentley sent me an email that articulated this point better, but I can't find it...

These changes are pulled from OpenBSD's vi manual page.