### PR TITLE
Fixes for a couple of memory leaks and a double free

### DIFF
--- a/common/exf.c
+++ b/common/exf.c
@@ -1160,6 +1160,7 @@ file_backup(SCR *sp, char *name, char *bname)
 		estr = wfname;
 		goto err;
 	}
+	free(d);
 	if (bp != NULL)
 		FREE_SPACE(sp, bp, blen);
 	return (0);

--- a/ex/ex_cscope.c
+++ b/ex/ex_cscope.c
@@ -495,6 +495,7 @@ cscope_find(SCR *sp, EXCMD *cmdp, CHAR_T *pattern)
 	if ((tqp = create_cs_cmd(sp, np, &search)) == NULL)
 		goto err;
 	free(np);
+	np = NULL;
 
 	/*
 	 * Stick the current context in a convenient place, we'll lose it

--- a/ex/ex_tag.c
+++ b/ex/ex_tag.c
@@ -593,8 +593,10 @@ tagf_copy(SCR *sp, TAGF *otfp, TAGF **tfpp)
 	*tfp = *otfp;
 
 	/* XXX: Allocate as part of the TAGF structure!!! */
-	if ((tfp->name = strdup(otfp->name)) == NULL)
+	if ((tfp->name = strdup(otfp->name)) == NULL) {
+		free(tfp);
 		return (1);
+	}
 
 	*tfpp = tfp;
 	return (0);


### PR DESCRIPTION
These problems were found with clang's static analyzer scan-build during a sweep through of memory problems in FreeBSD.