### PR TITLE
Fix UTF-8 detection.

### DIFF
--- a/common/encoding.c
+++ b/common/encoding.c
@@ -96,7 +96,7 @@ looks_utf8(const char *ibuf, size_t nbytes)
 				if (i >= nbytes)
 					goto done;
 
-				if (buf[i] & 0x40)	/* 10xxxxxx */
+				if ((buf[i] & 0xc0) != 0x80)	/* 10xxxxxx */
 					return -1;
 			}
 


### PR DESCRIPTION
Reported as https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=202290;
report and fix by: lampa@fit.vutbr.cz:

export LANG=cs_CZ.ISO8859-2
echo "á " >/tmp/x               # a acute (0xE1) and space
/usr/bin/vi /tmp/x
Conversion error on line 1;

hd /tmp/x
00000000  e1 20 0a

It happens only when "a acute" is succeeded by "space".