### PR TITLE
Fix -c option in wide char mode

### DIFF
--- a/common/exf.c
+++ b/common/exf.c
@@ -550,7 +550,7 @@ file_cinit(SCR *sp)
 		}
 		CHAR2INT(sp, gp->c_option, strlen(gp->c_option) + 1,
 			 wp, wlen);
-		if (ex_run_str(sp, "-c option", wp, wlen - 1, 1, 1))
+		if (ex_run_str(sp, "-c option", wp, wlen - 1, 1, 0))
 			return;
 		gp->c_option = NULL;
 	} else if (F_ISSET(sp, SC_EX)) {


### PR DESCRIPTION
When ex_run_str is called with nocopy=1 in wide char mode, it causes the command pointer to refer to the internal conv buffer from the call to CHAR2INT prior. This buffer is then corrupted later on with line data by db_get in the call to FILE2INT there. To test: echo foobar > file && nvi -e -c '/foo/p' file.