### PR TITLE
Add expandtab setting to use spaces instead of tabs, similar to vim.

### DIFF
--- a/common/options.c
+++ b/common/options.c
@@ -79,6 +79,8 @@ OPTLIST const optlist[] = {
 	{L("errorbells"),	NULL,		OPT_0BOOL,	0},
 /* O_ESCAPETIME	  4.4BSD */
 	{L("escapetime"),	NULL,		OPT_NUM,	0},
+/* O_EXPANDTAB	NetBSD 5.0 */
+	{L("expandtab"),	NULL,		OPT_0BOOL,	0},
 /* O_EXRC	System V (undocumented) */
 	{L("exrc"),	NULL,		OPT_0BOOL,	0},
 /* O_EXTENDED	  4.4BSD */
@@ -256,6 +258,7 @@ static OABBREV const abbrev[] = {
 	{L("dir"),	O_TMPDIR},		/*     4BSD */
 	{L("eb"),	O_ERRORBELLS},		/*     4BSD */
 	{L("ed"),	O_EDCOMPATIBLE},	/*     4BSD */
+	{L("et"),	O_EXPANDTAB},		/* NetBSD 5.0 */
 	{L("ex"),	O_EXRC},		/* System V (undocumented) */
 	{L("fe"),	O_FILEENCODING},
 	{L("ht"),	O_HARDTABS},		/*     4BSD */

--- a/ex/ex_shift.c
+++ b/ex/ex_shift.c
@@ -132,10 +132,13 @@ shift(SCR *sp, EXCMD *cmdp, enum which rl)
 		 * Build a new indent string and count the number of
 		 * characters it uses.
 		 */
-		for (tbp = bp, newidx = 0;
-		    newcol >= O_VAL(sp, O_TABSTOP); ++newidx) {
-			*tbp++ = '\t';
-			newcol -= O_VAL(sp, O_TABSTOP);
+		tbp = bp;
+		newidx = 0;
+		if (!O_ISSET(sp, O_EXPANDTAB)) {
+			for (; newcol >= O_VAL(sp, O_TABSTOP); ++newidx) {
+				*tbp++ = '\t';
+				newcol -= O_VAL(sp, O_TABSTOP);
+			}
 		}
 		for (; newcol > 0; --newcol, ++newidx)
 			*tbp++ = ' ';

--- a/ex/ex_txt.c
+++ b/ex/ex_txt.c
@@ -406,8 +406,12 @@ txt_dent(SCR *sp, TEXT *tp)
 	 *
 	 * Count up spaces/tabs needed to get to the target.
 	 */
-	for (cno = 0, tabs = 0; cno + COL_OFF(cno, ts) <= scno; ++tabs)
-		cno += COL_OFF(cno, ts);
+	cno = 0;
+	tabs = 0;
+	if (!O_ISSET(sp, O_EXPANDTAB)) {
+		for (; cno + COL_OFF(cno, ts) <= scno; ++tabs)
+			cno += COL_OFF(cno, ts);
+	}
 	spaces = scno - cno;
 
 	/* Make sure there's enough room. */

--- a/man/vi.1
+++ b/man/vi.1
@@ -1599,6 +1599,11 @@ and
 characters to move forward to the next
 .Ar shiftwidth
 column boundary.
+If the
+.Cm expandtab
+option is set, only insert
+.Aq space
+characters.
 .Pp
 .It Aq Cm erase
 .It Aq Cm control-H
@@ -2302,6 +2307,16 @@ The tenths of a second
 waits for a subsequent key to complete an
 .Aq escape
 key mapping.
+.It Cm expandtab , ex Bq off
+Expand
+.Aq tab
+characters to
+.Aq space
+when inserting, replacing or shifting text, autoindenting,
+indenting with
+.Aq Ic control-T ,
+or outdenting with
+.Aq Ic control-D .
 .It Cm exrc , ex Bq off
 Read the startup files in the local directory.
 .It Cm extended Bq off


### PR DESCRIPTION
The expandtab setting expands tabs to spaces in insert mode as well as when shifting and indenting/outdenting.  This is very useful when working on a code-base where the style dictates using spaces instead of tabs for indentation.  Originally ported from NetBSD, but has been extended to behave more like the vim implementation.