### PR TITLE
Don't expandtab when we're in command mode

### DIFF
--- a/vi/v_txt.c
+++ b/vi/v_txt.c
@@ -1205,7 +1205,8 @@ leftmargin:		tp->lb[tp->cno - 1] = ' ';
 		hexcnt = 1;
 		goto insq_ch;
 	case K_TAB:
-		if (quote != Q_VTHIS && O_ISSET(sp, O_EXPANDTAB)) {
+		if (sp->showmode != SM_COMMAND && quote != Q_VTHIS &&
+		    O_ISSET(sp, O_EXPANDTAB)) {
 			if (txt_dent(sp, tp, O_TABSTOP, 1))
 				goto err;
 			goto ebuf_chk;


### PR DESCRIPTION
otherwise you can't search for a tab unless you ^V escape it.

While we're here add a make distclean target.