### PR TITLE
Apply expandtab to lines replaced with a ! shell command

### DIFF
--- a/ex/ex_bang.c
+++ b/ex/ex_bang.c
@@ -173,6 +173,10 @@ ex_bang(SCR *sp, EXCMD *cmdp)
 	if (!F_ISSET(sp, SC_VI) && !F_ISSET(sp, SC_EX_SILENT))
 		(void)ex_puts(sp, "!\n");
 
+	/* Apply expandtab to the new text */
+	if (O_ISSET(sp, O_EXPANDTAB))
+		ex_retab(sp, cmdp);
+
 	/*
 	 * XXX
 	 * The ! commands never return an error, so that autoprint always

--- a/ex/ex_shift.c
+++ b/ex/ex_shift.c
@@ -21,7 +21,7 @@
 
 #include "../common/common.h"
 
-enum which {LEFT, RIGHT};
+enum which {RETAB, LEFT, RIGHT};
 static int shift(SCR *, EXCMD *, enum which);
 
 /*
@@ -45,6 +45,18 @@ int
 ex_shiftr(SCR *sp, EXCMD *cmdp)
 {
 	return (shift(sp, cmdp, RIGHT));
+}
+
+/*
+ * ex_retab -- Expand tabs (if enabled)
+ *
+ *
+ * PUBLIC: int ex_retab(SCR *, EXCMD *);
+ */
+int
+ex_retab(SCR *sp, EXCMD *cmdp)
+{
+	return (shift(sp, cmdp, RETAB));
 }
 
 /*
@@ -110,7 +122,9 @@ shift(SCR *sp, EXCMD *cmdp, enum which rl)
 				break;
 
 		/* Calculate the new indent amount. */
-		if (rl == RIGHT)
+		if (rl == RETAB)
+			newcol = oldcol;
+		else if (rl == RIGHT)
 			newcol = oldcol + sw;
 		else {
 			newcol = oldcol < sw ? 0 : oldcol - sw;

--- a/man/vi.1
+++ b/man/vi.1
@@ -2313,8 +2313,12 @@ characters to
 when inserting, replacing or shifting text, autoindenting,
 indenting with
 .Aq Ic control-T ,
-or outdenting with
-.Aq Ic control-D .
+outdenting with
+.Aq Ic control-D ,
+or
+when filtering lines with the
+.Cm !\&
+command.
 .It Cm exrc , ex Bq off
 Read the startup files in the local directory.
 .It Cm extended Bq off


### PR DESCRIPTION
Doing a shift right followed by a shift left is the minimal change. If you prefer it is not be difficult to add a third option to shift() that would expandtab without shifting, e.g:
```
diff --git a/ex/ex_shift.c b/ex/ex_shift.c
index d3c5508..5bc420d 100644
--- a/ex/ex_shift.c
+++ b/ex/ex_shift.c
@@ -21,9 +21,21 @@
 
 #include "../common/common.h"
 
-enum which {LEFT, RIGHT};
+enum which {EXPANDTAB, LEFT, RIGHT};
 static int shift(SCR *, EXCMD *, enum which);
 
+/*
+ * ex_expandtab -- Expand tabs (if enabled) without shifting
+ *
+ *
+ * PUBLIC: int ex_expandtab(SCR *, EXCMD *);
+ */
+int
+ex_expandtab(SCR *sp, EXCMD *cmdp)
+{
+       return (shift(sp, cmdp, EXPANDTAB));
+}
+
 /*
  * ex_shiftl -- :<[<...]
  *
@@ -112,7 +124,7 @@ shift(SCR *sp, EXCMD *cmdp, enum which rl)
                /* Calculate the new indent amount. */
                if (rl == RIGHT)
                        newcol = oldcol + sw;
-               else {
+               else if (rl == LEFT) {
                        newcol = oldcol < sw ? 0 : oldcol - sw;
                        if (newcol == oldcol) {
                                if (sp->lno == from)
```
Also it might be a good idea to document this in the man page?