### PR TITLE
Add vi/ex reference manual URL to man page

### DIFF
--- a/man/vi.1
+++ b/man/vi.1
@@ -2743,6 +2743,10 @@ and \*(Gt0 if an error occurs.
 .Xr ctags 1 ,
 .Xr iconv 1 ,
 .Xr re_format 7
+.Rs
+.%T vi/ex reference manual
+.%U https://docs.freebsd.org/44doc/usd/13.viref/paper.pdf
+.Re
 .Sh STANDARDS
 .Nm nex Ns / Ns Nm nvi
 is close to


### PR DESCRIPTION
Reported in [FreeBSD's Bugzilla PR 241985](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=241985)

The manual page references the "vi/ex reference manual" but there is no
information about where to find that document. Add a reference to the manual in
the `SEE ALSO` section since the FreeBSD Project hosts [a copy](https://docs.freebsd.org/44doc/usd/13.viref/paper.pdf) of it.

Test:
* `mandoc -T lint ./vi.1 && igor ./vi.1` seem happy
* `man ./vi.1` renders the page properly