### PR TITLE
fix -w option

### DIFF
--- a/common/main.c
+++ b/common/main.c
@@ -48,8 +48,8 @@ editor(GS *gp, int argc, char *argv[])
 	size_t len;
 	u_int flags;
 	int ch, flagchk, lflag, secure, startup, readonly, rval, silent;
-	char *tag_f, *wsizearg, path[256];
-	CHAR_T *w;
+	char *tag_f, *wsizearg;
+	CHAR_T *w, path[256];
 	size_t wlen;
 
 	/* Initialize the busy routine, if not defined by the screen. */
@@ -242,9 +242,9 @@ editor(GS *gp, int argc, char *argv[])
 	}
 	if (wsizearg != NULL) {
 		ARGS *av[2], a, b;
-		(void)snprintf(path, sizeof(path), "window=%s", wsizearg);
+		(void)SPRINTF(path, SIZE(path), L("window=%s"), wsizearg);
 		a.bp = (CHAR_T *)path;
-		a.len = strlen(path);
+		a.len = SIZE(path);
 		b.bp = NULL;
 		b.len = 0;
 		av[0] = &a;


### PR DESCRIPTION
Reported in FreeBSD's Bugzilla [PR 241985](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=241985)

Compose the `"window=%s"` option as a `CHAR_T` to be processed properly in
`opts_set`

Before the patch, trying this:

```
$ vi -w 10
```
shows an error:

```
set: no wo0 option: 'set all' gives all option values
Press Enter to continue:
```
And vi launches with as many lines as to fill the terminal screen
```
------------ BEGINING OF SCREEN

~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
~
------------ END OF SCREEN
```

After the patch, thre is no error

```
$ vi -w 10
```
and the vi screen is limited to the specified amount of lines:

```
------------ BEGINING OF SCREEN

~
~
~
~
~
~
~
~
~
------------ END OF SCREEN
```