### PR TITLE
Fix "add explicit braces to avoid dangling else" warnings.

### DIFF
--- a/catalog/dump.c
+++ b/catalog/dump.c
@@ -35,24 +35,24 @@ parse(FILE *fp)
 {
 	int ch, s1, s2, s3;
 
-#define	TESTD(s) {							\
+#define	TESTD(s) do {							\
 	if ((s = getc(fp)) == EOF)					\
 		return;							\
 	if (!isdigit(s))						\
 		continue;						\
-}
-#define	TESTP {								\
+} while (0)
+#define	TESTP do {							\
 	if ((ch = getc(fp)) == EOF)					\
 		return;							\
 	if (ch != '|')							\
 		continue;						\
-}
-#define	MOVEC(t) {							\
+} while (0)
+#define	MOVEC(t) do {							\
 	do {								\
 		if ((ch = getc(fp)) == EOF)				\
 			return;						\
 	} while (ch != (t));						\
-}
+} while (0)
 	for (;;) {
 		MOVEC('"');
 		TESTD(s1);

--- a/cl/cl_term.c
+++ b/cl/cl_term.c
@@ -424,16 +424,18 @@ cl_ssize(SCR *sp, int sigwinch, size_t *rowp, size_t *colp, int *changedp)
 	if (row == 0 || col == 0) {
 		if ((p = getenv("TERM")) == NULL)
 			goto noterm;
-		if (row == 0)
+		if (row == 0) {
 			if ((rval = tigetnum("lines")) < 0)
 				msgq(sp, M_SYSERR, "tigetnum: lines");
 			else
 				row = rval;
-		if (col == 0)
+		}
+		if (col == 0) {
 			if ((rval = tigetnum("cols")) < 0)
 				msgq(sp, M_SYSERR, "tigetnum: cols");
 			else
 				col = rval;
+		}
 	}
 
 	/* If nothing else, well, it's probably a VT100. */

--- a/common/cut.h
+++ b/common/cut.h
@@ -63,13 +63,13 @@ struct _text {				/* Text: a linked list of lines. */
  * Get named buffer 'name'.
  * Translate upper-case buffer names to lower-case buffer names.
  */
-#define	CBNAME(sp, cbp, nch) {						\
+#define	CBNAME(sp, cbp, nch) do {					\
 	CHAR_T L__name;							\
 	L__name = isupper(nch) ? tolower(nch) : (nch);			\
 	SLIST_FOREACH(cbp, sp->gp->cutq, q)				\
 		if (cbp->name == L__name)				\
 			break;						\
-}
+} while (0)
 
 /* Flags to the cut() routine. */
 #define	CUT_LINEMODE	0x01		/* Cut in line mode. */

--- a/common/exf.c
+++ b/common/exf.c
@@ -887,7 +887,7 @@ success_open:
 	 * we re-init the time.  That way the user can clean up the disk
 	 * and rewrite without having to force it.
 	 */
-	if (noname)
+	if (noname) {
 		if (stat(name, &sb))
 			timepoint_system(&ep->mtim);
 		else {
@@ -897,6 +897,7 @@ success_open:
 
 			ep->mtim = sb.st_mtim;
 		}
+	}
 
 	/*
 	 * If the write failed, complain loudly.  ex_writefp() has already
@@ -925,11 +926,12 @@ success_open:
 	 */
 	if (LF_ISSET(FS_ALL) && !LF_ISSET(FS_APPEND)) {
 		F_CLR(ep, F_MODIFIED);
-		if (F_ISSET(frp, FR_TMPFILE))
+		if (F_ISSET(frp, FR_TMPFILE)) {
 			if (noname)
 				F_SET(frp, FR_TMPEXIT);
 			else
 				F_CLR(frp, FR_TMPEXIT);
+		}
 	}
 
 	p = msg_print(sp, name, &nf);
@@ -1290,7 +1292,7 @@ file_m1(SCR *sp, int force, int flags)
 	 * unless force is also set.  Otherwise, we fail unless forced or
 	 * there's another open screen on this file.
 	 */
-	if (F_ISSET(ep, F_MODIFIED))
+	if (F_ISSET(ep, F_MODIFIED)) {
 		if (O_ISSET(sp, O_AUTOWRITE)) {
 			if (!force && file_aw(sp, flags))
 				return (1);
@@ -1300,6 +1302,7 @@ file_m1(SCR *sp, int force, int flags)
 "263|File modified since last complete write; write or use :edit! to override");
 			return (1);
 		}
+	}
 
 	return (file_m3(sp, force));
 }

--- a/common/key.c
+++ b/common/key.c
@@ -424,12 +424,12 @@ v_event_append(SCR *sp, EVENT *argp)
 }
 
 /* Remove events from the queue. */
-#define	QREM(len) {							\
+#define	QREM(len) do {							\
 	if ((gp->i_cnt -= len) == 0)					\
 		gp->i_next = 0;						\
 	else								\
 		gp->i_next += len;					\
-}
+} while (0)
 
 /*
  * v_event_get --

--- a/common/log.c
+++ b/common/log.c
@@ -69,10 +69,10 @@ static int	apply_with(int (*)(SCR *, recno_t, CHAR_T *, size_t),
 					SCR *, recno_t, u_char *, size_t);
 
 /* Try and restart the log on failure, i.e. if we run out of memory. */
-#define	LOG_ERR {							\
+#define	LOG_ERR do {							\
 	log_err(sp, __FILE__, __LINE__);				\
 	return (1);							\
-}
+} while (0)
 
 /* offset of CHAR_T string in log needs to be aligned on some systems
  * because it is passed to db_set as a string

--- a/common/main.c
+++ b/common/main.c
@@ -533,7 +533,7 @@ v_obsolete(char *argv[])
 				argv[0][1] = 'c';
 				(void)strlcpy(argv[0] + 2, p + 1, len);
 			}
-		} else if (argv[0][0] == '-')
+		} else if (argv[0][0] == '-') {
 			if (argv[0][1] == '\0') {
 				argv[0] = strdup("-s");
 				if (argv[0] == NULL) {
@@ -545,6 +545,7 @@ nomem:					warn(NULL);
 				    argv[0][1] == 't' || argv[0][1] == 'w') &&
 				    argv[0][2] == '\0')
 					++argv;
+		}
 	return (0);
 }
 

--- a/common/mark.c
+++ b/common/mark.c
@@ -216,12 +216,13 @@ mark_insdel(SCR *sp, lnop_t op, recno_t lno)
 		abort();
 	case LINE_DELETE:
 		SLIST_FOREACH(lmp, sp->ep->marks, q)
-			if (lmp->lno >= lno)
+			if (lmp->lno >= lno) {
 				if (lmp->lno == lno) {
 					F_SET(lmp, MARK_DELETED);
 					(void)log_mark(sp, lmp);
 				} else
 					--lmp->lno;
+			}
 		break;
 	case LINE_INSERT:
 		/*

--- a/common/mem.h
+++ b/common/mem.h
@@ -17,7 +17,7 @@
 /* Increase the size of a malloc'd buffer.  Two versions, one that
  * returns, one that jumps to an error label.
  */
-#define	BINC_GOTO(sp, type, lp, llen, nlen) {				\
+#define	BINC_GOTO(sp, type, lp, llen, nlen) do {			\
 	CHECK_TYPE(type *, lp)						\
 	void *L__bincp;							\
 	if ((nlen) > llen) {						\
@@ -29,12 +29,12 @@
 		 */							\
 		lp = L__bincp;						\
 	}								\
-}
+} while (0)
 #define	BINC_GOTOC(sp, lp, llen, nlen)					\
 	BINC_GOTO(sp, char, lp, llen, nlen)
 #define	BINC_GOTOW(sp, lp, llen, nlen)					\
 	BINC_GOTO(sp, CHAR_T, lp, llen, (nlen) * sizeof(CHAR_T))
-#define	BINC_RET(sp, type, lp, llen, nlen) {				\
+#define	BINC_RET(sp, type, lp, llen, nlen) do {				\
 	CHECK_TYPE(type *, lp)						\
 	void *L__bincp;							\
 	if ((nlen) > llen) {						\
@@ -46,7 +46,7 @@
 		 */							\
 		lp = L__bincp;						\
 	}								\
-}
+} while (0)
 #define	BINC_RETC(sp, lp, llen, nlen)					\
 	BINC_RET(sp, char, lp, llen, nlen)
 #define	BINC_RETW(sp, lp, llen, nlen)					\
@@ -57,7 +57,7 @@
  * from a malloc'd buffer otherwise.  Two versions, one that returns, one
  * that jumps to an error label.
  */
-#define	GET_SPACE_GOTO(sp, type, bp, blen, nlen) {			\
+#define	GET_SPACE_GOTO(sp, type, bp, blen, nlen) do {			\
 	CHECK_TYPE(type *, bp)						\
 	GS *L__gp = (sp) == NULL ? NULL : (sp)->gp;			\
 	if (L__gp == NULL || F_ISSET(L__gp, G_TMP_INUSE)) {		\
@@ -70,12 +70,12 @@
 		blen = L__gp->tmp_blen;					\
 		F_SET(L__gp, G_TMP_INUSE);				\
 	}								\
-}
+} while (0)
 #define	GET_SPACE_GOTOC(sp, bp, blen, nlen)				\
 	GET_SPACE_GOTO(sp, char, bp, blen, nlen)
 #define	GET_SPACE_GOTOW(sp, bp, blen, nlen)				\
 	GET_SPACE_GOTO(sp, CHAR_T, bp, blen, (nlen) * sizeof(CHAR_T))
-#define	GET_SPACE_RET(sp, type, bp, blen, nlen) {			\
+#define	GET_SPACE_RET(sp, type, bp, blen, nlen) do {			\
 	CHECK_TYPE(type *, bp)						\
 	GS *L__gp = (sp) == NULL ? NULL : (sp)->gp;			\
 	if (L__gp == NULL || F_ISSET(L__gp, G_TMP_INUSE)) {		\
@@ -88,7 +88,7 @@
 		blen = L__gp->tmp_blen;					\
 		F_SET(L__gp, G_TMP_INUSE);				\
 	}								\
-}
+} while (0)
 #define	GET_SPACE_RETC(sp, bp, blen, nlen)				\
 	GET_SPACE_RET(sp, char, bp, blen, nlen)
 #define	GET_SPACE_RETW(sp, bp, blen, nlen)				\
@@ -98,7 +98,7 @@
  * Add space to a GET_SPACE returned buffer.  Two versions, one that
  * returns, one that jumps to an error label.
  */
-#define	ADD_SPACE_GOTO(sp, type, bp, blen, nlen) {			\
+#define	ADD_SPACE_GOTO(sp, type, bp, blen, nlen) do {			\
 	CHECK_TYPE(type *, bp)						\
 	GS *L__gp = (sp) == NULL ? NULL : (sp)->gp;			\
 	if (L__gp == NULL || bp == (type *)L__gp->tmp_bp) {		\
@@ -109,12 +109,12 @@
 		F_SET(L__gp, G_TMP_INUSE);				\
 	} else								\
 		BINC_GOTO(sp, type, bp, blen, nlen);			\
-}
+} while (0)
 #define	ADD_SPACE_GOTOC(sp, bp, blen, nlen)				\
 	ADD_SPACE_GOTO(sp, char, bp, blen, nlen)
 #define	ADD_SPACE_GOTOW(sp, bp, blen, nlen)				\
 	ADD_SPACE_GOTO(sp, CHAR_T, bp, blen, (nlen) * sizeof(CHAR_T))
-#define	ADD_SPACE_RET(sp, type, bp, blen, nlen) {			\
+#define	ADD_SPACE_RET(sp, type, bp, blen, nlen) do {			\
 	CHECK_TYPE(type *, bp)						\
 	GS *L__gp = (sp) == NULL ? NULL : (sp)->gp;			\
 	if (L__gp == NULL || bp == (type *)L__gp->tmp_bp) {		\
@@ -125,70 +125,70 @@
 		F_SET(L__gp, G_TMP_INUSE);				\
 	} else								\
 		BINC_RET(sp, type, bp, blen, nlen);			\
-}
+} while (0)
 #define	ADD_SPACE_RETC(sp, bp, blen, nlen)				\
 	ADD_SPACE_RET(sp, char, bp, blen, nlen)
 #define	ADD_SPACE_RETW(sp, bp, blen, nlen)				\
 	ADD_SPACE_RET(sp, CHAR_T, bp, blen, (nlen) * sizeof(CHAR_T))
 
 /* Free a GET_SPACE returned buffer. */
-#define	FREE_SPACE(sp, bp, blen) {					\
+#define	FREE_SPACE(sp, bp, blen) do {					\
 	GS *L__gp = (sp) == NULL ? NULL : (sp)->gp;			\
 	if (L__gp != NULL && bp == L__gp->tmp_bp)			\
 		F_CLR(L__gp, G_TMP_INUSE);				\
 	else								\
 		free(bp);						\
-}
-#define	FREE_SPACEW(sp, bp, blen) {					\
+} while (0)
+#define	FREE_SPACEW(sp, bp, blen) do {					\
 	CHECK_TYPE(CHAR_T *, bp)					\
 	FREE_SPACE(sp, (char *)bp, blen);				\
-}
+} while (0)
 
 /*
  * Malloc a buffer, casting the return pointer.  Various versions.
  */
-#define	CALLOC(sp, p, nmemb, size) {					\
+#define	CALLOC(sp, p, nmemb, size) do {					\
 	if ((p = calloc(nmemb, size)) == NULL)				\
 		msgq(sp, M_SYSERR, NULL);				\
-}
-#define	CALLOC_GOTO(sp, p, nmemb, size) {				\
+} while (0)
+#define	CALLOC_GOTO(sp, p, nmemb, size) do {				\
 	if ((p = calloc(nmemb, size)) == NULL)				\
 		goto alloc_err;						\
-}
-#define	CALLOC_RET(sp, p, nmemb, size) {				\
+} while (0)
+#define	CALLOC_RET(sp, p, nmemb, size) do {				\
 	if ((p = calloc(nmemb, size)) == NULL) {			\
 		msgq(sp, M_SYSERR, NULL);				\
 		return (1);						\
 	}								\
-}
+} while (0)
 
-#define	MALLOC(sp, p, size) {						\
+#define	MALLOC(sp, p, size) do {					\
 	if ((p = malloc(size)) == NULL)					\
 		msgq(sp, M_SYSERR, NULL);				\
-}
-#define	MALLOC_GOTO(sp, p, size) {					\
+} while (0)
+#define	MALLOC_GOTO(sp, p, size) do {					\
 	if ((p = malloc(size)) == NULL)					\
 		goto alloc_err;						\
-}
-#define	MALLOC_RET(sp, p, size) {					\
+} while (0)
+#define	MALLOC_RET(sp, p, size) do {					\
 	if ((p = malloc(size)) == NULL) {				\
 		msgq(sp, M_SYSERR, NULL);				\
 		return (1);						\
 	}								\
-}
+} while (0)
 
 /*
  * Resize a buffer, free any already held memory if we can't get more.
  * FreeBSD's reallocf(3) does the same thing, but it's not portable yet.
  */
-#define	REALLOC(sp, p, cast, size) {					\
+#define	REALLOC(sp, p, cast, size) do {					\
 	cast newp;							\
 	if ((newp = realloc(p, size)) == NULL) {			\
 		free(p);						\
 		msgq(sp, M_SYSERR, NULL);				\
 	}								\
 	p = newp;							\
-}
+} while (0)
 
 /* 
  * p2roundup --

--- a/common/options.c
+++ b/common/options.c
@@ -313,7 +313,7 @@ opts_init(SCR *sp, int *oargs)
 	argv[1] = &b;
 
 	/* Set numeric and string default values. */
-#define	OI(indx, str) {							\
+#define	OI(indx, str) do {						\
 	a.len = STRLEN(str);						\
 	if ((CHAR_T*)str != b2)	  /* GCC puts strings in text-space. */	\
 		(void)MEMCPY(b2, str, a.len+1);				\
@@ -321,7 +321,7 @@ opts_init(SCR *sp, int *oargs)
 		 optindx = indx;					\
 		goto err;						\
 	}								\
-}
+} while (0)
 	/*
 	 * Indirect global options to global space.  Specifically, set up
 	 * terminal, lines, columns first, they're used by other options.
@@ -574,13 +574,14 @@ opts_set(SCR *sp, ARGS *argv[], char *usage)
 			 * functions can be expensive.
 			 */
 			isset = !turnoff;
-			if (!F_ISSET(op, OPT_ALWAYS))
+			if (!F_ISSET(op, OPT_ALWAYS)) {
 				if (isset) {
 					if (O_ISSET(sp, offset))
 						break;
 				} else
 					if (!O_ISSET(sp, offset))
 						break;
+			}
 
 			/* Report to subsystems. */
 			if ((op->func != NULL &&

--- a/common/put.c
+++ b/common/put.c
@@ -39,7 +39,7 @@ put(SCR *sp, CB *cbp, CHAR_T *namep, MARK *cp, MARK *rp, int append)
 	CHAR_T *bp, *t;
 	CHAR_T *p;
 
-	if (cbp == NULL)
+	if (cbp == NULL) {
 		if (namep == NULL) {
 			cbp = sp->gp->dcbp;
 			if (cbp == NULL) {
@@ -56,6 +56,7 @@ put(SCR *sp, CB *cbp, CHAR_T *namep, MARK *cp, MARK *rp, int append)
 				return (1);
 			}
 		}
+	}
 	tp = TAILQ_FIRST(cbp->textq);
 
 	/*

--- a/ex/ex.c
+++ b/ex/ex.c
@@ -811,13 +811,14 @@ skip_srch:	if (ecp->cmd == &cmds[C_VISUAL_EX] && F_ISSET(sp, SC_VI))
 	 * this isn't a particularly complex trap, and if backslashes were
 	 * legal in set commands, this would have to be much more complicated.
 	 */
-	if (ecp->cmd == &cmds[C_SET])
+	if (ecp->cmd == &cmds[C_SET]) {
 		for (p = ecp->cp, len = ecp->clen; len > 0; --len, ++p)
 			if (IS_ESCAPE(sp, ecp, *p) && len > 1) {
 				--len;
 				++p;
 			} else if (*p == '\\')
 				*p = CH_LITERAL;
+	}
 
 	/*
 	 * Set the default addresses.  It's an error to specify an address for
@@ -1254,7 +1255,7 @@ addr_verify:
 				ex_badaddr(sp, ecp->cmd, A_ZERO, NUM_OK);
 				goto err;
 			}
-		} else if (!db_exist(sp, ecp->addr2.lno))
+		} else if (!db_exist(sp, ecp->addr2.lno)) {
 			if (FL_ISSET(ecp->iflags, E_C_COUNT)) {
 				if (db_last(sp, &lno))
 					goto err;
@@ -1263,6 +1264,7 @@ addr_verify:
 				ex_badaddr(sp, NULL, A_EOF, NUM_OK);
 				goto err;
 			}
+		}
 		/* FALLTHROUGH */
 	case 1:
 		if (ecp->addr1.lno == 0) {
@@ -2117,7 +2119,7 @@ ex_load(SCR *sp)
 
 			/* If it's a global/v command, fix up the last line. */
 			if (FL_ISSET(ecp->agv_flags,
-			    AGV_GLOBAL | AGV_V) && ecp->range_lno != OOBLNO)
+			    AGV_GLOBAL | AGV_V) && ecp->range_lno != OOBLNO) {
 				if (db_exist(sp, ecp->range_lno))
 					sp->lno = ecp->range_lno;
 				else {
@@ -2126,6 +2128,7 @@ ex_load(SCR *sp)
 					if (sp->lno == 0)
 						sp->lno = 1;
 				}
+			}
 			free(ecp->o_cp);
 		}
 

--- a/ex/ex.h
+++ b/ex/ex.h
@@ -55,12 +55,12 @@ extern EXCMDLIST const cmds[];		/* Table of ex commands. */
  * at any time, and most of them won't work well if a file hasn't yet been read
  * in.  Historic vi generally took the easy way out and dropped core.
  */
-#define	NEEDFILE(sp, cmdp) {						\
+#define	NEEDFILE(sp, cmdp) do {						\
 	if ((sp)->ep == NULL) {						\
 		ex_wemsg(sp, (cmdp)->cmd->name, EXM_NOFILEYET);		\
 		return (1);						\
 	}								\
-}
+} while (0)
 
 /* Range structures for global and @ commands. */
 typedef struct _range RANGE;
@@ -102,12 +102,12 @@ struct _excmd {
 	u_int8_t  agv_flags;
 
 	/* Clear the structure before each ex command. */
-#define	CLEAR_EX_CMD(cmdp) {						\
+#define	CLEAR_EX_CMD(cmdp) do {						\
 	u_int32_t L__f = F_ISSET(cmdp, E_PRESERVE);			\
 	memset(&((cmdp)->buffer), 0, ((char *)&(cmdp)->flags -		\
 	    (char *)&((cmdp)->buffer)) + sizeof((cmdp)->flags));	\
 	F_SET(cmdp, L__f);						\
-}
+} while (0)
 
 	CHAR_T	  buffer;		/* Command: named buffer. */
 	recno_t	  lineno;		/* Command: line number. */

--- a/ex/ex_bang.c
+++ b/ex/ex_bang.c
@@ -96,7 +96,7 @@ ex_bang(SCR *sp, EXCMD *cmdp)
 	 */
 	if (cmdp->addrcnt == 0) {
 		msg = NULL;
-		if (sp->ep != NULL && F_ISSET(sp->ep, F_MODIFIED))
+		if (sp->ep != NULL && F_ISSET(sp->ep, F_MODIFIED)) {
 			if (O_ISSET(sp, O_AUTOWRITE)) {
 				if (file_aw(sp, FS_ALL))
 					return (0);
@@ -105,6 +105,7 @@ ex_bang(SCR *sp, EXCMD *cmdp)
 				msg = msg_cat(sp,
 				    "303|File modified since last write.",
 				    NULL);
+		}
 
 		/* If we're still in a vi screen, move out explicitly. */
 		INT2CHAR(sp, ap->bp, ap->len+1, np, nlen);

--- a/ex/ex_cscope.c
+++ b/ex/ex_cscope.c
@@ -844,7 +844,7 @@ csc_help(SCR *sp, char *cmd)
 {
 	CC const *ccp;
 
-	if (cmd != NULL && *cmd != '\0')
+	if (cmd != NULL && *cmd != '\0') {
 		if ((ccp = lookup_ccmd(cmd)) == NULL) {
 			ex_printf(sp,
 			    "%s doesn't match any cscope command\n", cmd);
@@ -855,6 +855,7 @@ csc_help(SCR *sp, char *cmd)
 			ex_printf(sp, "  Usage: %s\n", ccp->usage_msg);
 			return (0);
 		}
+	}
 
 	ex_printf(sp, "cscope commands:\n");
 	for (ccp = cscope_cmds; ccp->name != NULL; ++ccp)

--- a/ex/ex_filter.c
+++ b/ex/ex_filter.c
@@ -174,11 +174,12 @@ err:		if (input[0] != -1)
 		if (ex_readfp(sp, "filter", ofp, fm, &nread, 1))
 			rval = 1;
 		sp->rptlines[L_ADDED] += nread;
-		if (ftype == FILTER_READ)
+		if (ftype == FILTER_READ) {
 			if (fm->lno == 0)
 				rp->lno = nread;
 			else
 				rp->lno += nread;
+		}
 		goto uwait;
 	}
 

--- a/ex/ex_global.c
+++ b/ex/ex_global.c
@@ -112,11 +112,12 @@ usage:		ex_emsg(sp, cmdp->cmd->usage, EXM_USAGE);
 			*t = '\0';
 			break;
 		}
-		if (p[0] == '\\')
+		if (p[0] == '\\') {
 			if (p[1] == delim)
 				++p;
 			else if (p[1] == '\\')
 				*t++ = *p++;
+		}
 		*t++ = *p++;
 	}
 

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -115,11 +115,12 @@ subagain:	return (ex_subagain(sp, cmdp));
 			*t = '\0';
 			break;
 		}
-		if (p[0] == '\\')
+		if (p[0] == '\\') {
 			if (p[1] == delim)
 				++p;
 			else if (p[1] == '\\')
 				*t++ = *p++;
+		}
 		*t++ = *p++;
 	}
 
@@ -296,7 +297,7 @@ ex_subtilde(SCR *sp, EXCMD *cmdp)
  * when the replacement is done.  Don't change it unless you're *damned*
  * confident.
  */
-#define	NEEDNEWLINE(sp) {						\
+#define	NEEDNEWLINE(sp) do {						\
 	if (sp->newl_len == sp->newl_cnt) {				\
 		sp->newl_len += 25;					\
 		REALLOC(sp, sp->newl, size_t *,				\
@@ -306,9 +307,9 @@ ex_subtilde(SCR *sp, EXCMD *cmdp)
 			return (1);					\
 		}							\
 	}								\
-}
+} while (0)
 
-#define	BUILD(sp, l, len) {						\
+#define	BUILD(sp, l, len) do {						\
 	if (lbclen + (len) > lblen) {					\
 		lblen = p2roundup(MAX(lbclen + (len), 256));		\
 		REALLOC(sp, lb, CHAR_T *, lblen * sizeof(CHAR_T));	\
@@ -319,9 +320,9 @@ ex_subtilde(SCR *sp, EXCMD *cmdp)
 	}								\
 	MEMCPY(lb + lbclen, l, len);					\
 	lbclen += len;							\
-}
+} while (0)
 
-#define	NEEDSP(sp, len, pnt) {						\
+#define	NEEDSP(sp, len, pnt) do {					\
 	if (lbclen + (len) > lblen) {					\
 		lblen = p2roundup(MAX(lbclen + (len), 256));		\
 		REALLOC(sp, lb, CHAR_T *, lblen * sizeof(CHAR_T));	\
@@ -331,7 +332,7 @@ ex_subtilde(SCR *sp, EXCMD *cmdp)
 		}							\
 		pnt = lb + lbclen;					\
 	}								\
-}
+} while (0)
 
 static int
 s(SCR *sp, EXCMD *cmdp, CHAR_T *s, regex_t *re, u_int flags)
@@ -584,7 +585,7 @@ nextmatch:	match[0].rm_so = 0;
 			empty_ok = 1;
 			if (len == 0)
 				goto endmatch;
-			BUILD(sp, s + offset, 1)
+			BUILD(sp, s + offset, 1);
 			++offset;
 			--len;
 			goto nextmatch;
@@ -710,7 +711,7 @@ skip:		offset += match[0].rm_eo;
 
 			/* Copy the rest of the line. */
 			if (len)
-				BUILD(sp, s + offset, len)
+				BUILD(sp, s + offset, len);
 
 			/* Set the new offset. */
 			offset = saved_offset;
@@ -736,7 +737,7 @@ skip:		offset += match[0].rm_eo;
 				goto err;
 			if (db_get(sp, lno, DBG_FATAL, &s, &llen))
 				goto err;
-			ADD_SPACE_RETW(sp, bp, blen, llen)
+			ADD_SPACE_RETW(sp, bp, blen, llen);
 			MEMCPY(bp, s, llen);
 			s = bp;
 			len = llen - offset;
@@ -779,7 +780,7 @@ endmatch:	if (!linechanged)
 
 		/* Copy any remaining bytes into the build buffer. */
 		if (len)
-			BUILD(sp, s + offset, len)
+			BUILD(sp, s + offset, len);
 
 		/* Store inserted lines, adjusting the build buffer. */
 		last = 0;
@@ -1333,7 +1334,7 @@ re_sub(
 	 * Otherwise, since this is the lowest level of replacement, discard
 	 * all escaping characters.  This (hopefully) matches historic practice.
 	 */
-#define	OUTCH(ch, nltrans) {						\
+#define	OUTCH(ch, nltrans) do {						\
 	ARG_CHAR_T __ch = (ch);						\
 	e_key_t __value = KEY_VAL(sp, __ch);				\
 	if (nltrans && (__value == K_CR || __value == K_NL)) {		\
@@ -1362,7 +1363,7 @@ re_sub(
 	NEEDSP(sp, 1, p);						\
 	*p++ = __ch;							\
 	++lbclen;							\
-}
+} while (0)
 	conv = C_NOTSET;
 	for (rp = sp->repl, rpl = sp->repl_len, p = lb + lbclen; rpl--;) {
 		switch (ch = *rp++) {

--- a/regex/engine.c
+++ b/regex/engine.c
@@ -118,7 +118,7 @@ static char *pchar(int ch);
 #ifdef REDEBUG
 #define	SP(t, s, c)	print(m, t, s, c, stdout)
 #define	AT(t, p1, p2, s1, s2)	at(m, t, p1, p2, s1, s2)
-#define	NOTE(str)	{ if (m->eflags&REG_TRACE) printf("=%s\n", (str)); }
+#define	NOTE(str)	do { if (m->eflags&REG_TRACE) printf("=%s\n", (str)); } while(0);
 #else
 #define	SP(t, s, c)	/* nothing */
 #define	AT(t, p1, p2, s1, s2)	/* nothing */

--- a/regex/regexec.c
+++ b/regex/regexec.c
@@ -114,10 +114,10 @@ static char sccsid[] = "@(#)regexec.c	8.2 (Berkeley) 3/16/94";
 #define	ASSIGN(d, s)	memcpy(d, s, m->g->nstates)
 #define	EQ(a, b)	(memcmp(a, b, m->g->nstates) == 0)
 #define	STATEVARS	int vn; char *space
-#define	STATESETUP(m, nv)	{ (m)->space = malloc((nv)*(m)->g->nstates); \
+#define	STATESETUP(m, nv)	do { (m)->space = malloc((nv)*(m)->g->nstates); \
 				if ((m)->space == NULL) return(REG_ESPACE); \
-				(m)->vn = 0; }
-#define	STATETEARDOWN(m)	{ free((m)->space); }
+				(m)->vn = 0; } while (0)
+#define	STATETEARDOWN(m)	free((m)->space)
 #define	SETUP(v)	((v) = &m->space[m->vn++ * m->g->nstates])
 #define	onestate	int
 #define	INIT(o, n)	((o) = (n))

--- a/vi/v_itxt.c
+++ b/vi/v_itxt.c
@@ -48,10 +48,10 @@
  * position.)  We also check for mapped keys waiting, i.e. if we're in the
  * middle of a map, don't bother logging the cursor.
  */
-#define	LOG_CORRECT {							\
+#define	LOG_CORRECT do {						\
 	if (!MAPPED_KEYS_WAITING(sp))					\
 		(void)log_cursor(sp);					\
-}
+} while (0)
 
 static u_int32_t set_txt_std(SCR *, VICMD *, u_int32_t);
 

--- a/vi/v_paragraph.c
+++ b/vi/v_paragraph.c
@@ -23,7 +23,7 @@
 #include "../common/common.h"
 #include "vi.h"
 
-#define	INTEXT_CHECK {							\
+#define	INTEXT_CHECK do {						\
 	if (len == 0 || v_isempty(p, len)) {				\
 		if (!--cnt)						\
 			goto found;					\
@@ -48,7 +48,7 @@
 		    (lp[1] == ' ' && len == 2 || lp[1] == p[2]) &&	\
 		    !--cnt)						\
 			goto found;					\
-}
+} while (0)
 
 /*
  * v_paragraphf -- [count]}
@@ -83,7 +83,7 @@ v_paragraphf(SCR *sp, VICMD *vp)
 	 * line itself remained.  If somebody complains, don't pause, don't
 	 * hesitate, just hit them.
 	 */
-	if (ISMOTION(vp))
+	if (ISMOTION(vp)) {
 		if (vp->m_start.cno == 0)
 			F_SET(vp, VM_LMODE);
 		else {
@@ -94,6 +94,7 @@ v_paragraphf(SCR *sp, VICMD *vp)
 			if (vp->m_start.cno <= vp->m_stop.cno)
 				F_SET(vp, VM_LMODE);
 		}
+	}
 
 	/* Figure out what state we're currently in. */
 	lno = vp->m_start.lno;
@@ -226,7 +227,7 @@ v_paragraphb(SCR *sp, VICMD *vp)
 	 */
 	lno = vp->m_start.lno;
 
-	if (ISMOTION(vp))
+	if (ISMOTION(vp)) {
 		if (vp->m_start.cno == 0) {
 			if (vp->m_start.lno == 1) {
 				v_sof(sp, &vp->m_start);
@@ -236,6 +237,7 @@ v_paragraphb(SCR *sp, VICMD *vp)
 			F_SET(vp, VM_LMODE);
 		} else
 			--vp->m_start.cno;
+	}
 
 	if (vp->m_start.lno <= 1)
 		goto sof;

--- a/vi/v_section.c
+++ b/vi/v_section.c
@@ -77,7 +77,7 @@ v_sectionf(SCR *sp, VICMD *vp)
 	 * check here, because we know that the end is going to be the start
 	 * or end of a line.
 	 */
-	if (ISMOTION(vp))
+	if (ISMOTION(vp)) {
 		if (vp->m_start.cno == 0)
 			F_SET(vp, VM_LMODE);
 		else {
@@ -88,6 +88,7 @@ v_sectionf(SCR *sp, VICMD *vp)
 			if (vp->m_start.cno <= vp->m_stop.cno)
 				F_SET(vp, VM_LMODE);
 		}
+	}
 
 	cnt = F_ISSET(vp, VC_C1SET) ? vp->count : 1;
 	for (lno = vp->m_start.lno; !db_get(sp, ++lno, 0, &p, &len);) {

--- a/vi/v_sentence.c
+++ b/vi/v_sentence.c
@@ -336,7 +336,7 @@ okret:	vp->m_stop.lno = cs.cs_lno;
 	 * All commands move to the end of the range.  Adjust the start of
 	 * the range for motion commands.
 	 */
-	if (ISMOTION(vp))
+	if (ISMOTION(vp)) {
 		if (vp->m_start.cno == 0 &&
 		    (cs.cs_flags != 0 || vp->m_stop.cno == 0)) {
 			if (db_get(sp,
@@ -346,6 +346,7 @@ okret:	vp->m_stop.lno = cs.cs_lno;
 			F_SET(vp, VM_LMODE);
 		} else
 			--vp->m_start.cno;
+	}
 	vp->m_final = vp->m_stop;
 	return (0);
 }

--- a/vi/v_txt.c
+++ b/vi/v_txt.c
@@ -221,10 +221,10 @@ txt_map_end(SCR *sp)
  * Internally, we maintain tp->lno and tp->cno, externally, everyone uses
  * sp->lno and sp->cno.  Make them consistent as necessary.
  */
-#define	UPDATE_POSITION(sp, tp) {					\
+#define	UPDATE_POSITION(sp, tp) do {					\
 	(sp)->lno = (tp)->lno;						\
 	(sp)->cno = (tp)->cno;						\
-}
+} while (0)
 
 /*
  * v_txt --
@@ -677,7 +677,7 @@ k_cr:		if (LF_ISSET(TXT_CR)) {
 			goto k_escape;
 		}
 
-#define	LINE_RESOLVE {							\
+#define	LINE_RESOLVE do {						\
 		/*							\
 		 * Handle abbreviations.  If there was one, discard the	\
 		 * replay characters.					\
@@ -708,7 +708,7 @@ k_cr:		if (LF_ISSET(TXT_CR)) {
 			--tp->len;					\
 			--tp->insert;					\
 		}							\
-}
+} while (0)
 		LINE_RESOLVE;
 
 		/*
@@ -1527,7 +1527,7 @@ txt_abbrev(SCR *sp, TEXT *tp, CHAR_T *pushcp, int isinfoline, int *didsubp, int 
 	 *
 	 * This makes the layering look like a Nachos Supreme.
 	 */
-search:	if (isinfoline)
+search:	if (isinfoline) {
 		if (off == tp->ai || off == tp->offset)
 			if (ex_is_abbrev(p, len)) {
 				*turnoffp = 1;
@@ -1537,6 +1537,7 @@ search:	if (isinfoline)
 		else
 			if (*turnoffp)
 				return (0);
+	}
 
 	/* Check for any abbreviations. */
 	if ((qp = seq_find(sp, NULL, NULL, p, len, SEQ_ABBREV, NULL)) == NULL)

--- a/vi/vi.c
+++ b/vi/vi.c
@@ -405,7 +405,7 @@ ret:		rval = 1;
 	return (rval);
 }
 
-#define	KEY(key, ec_flags) {						\
+#define	KEY(key, ec_flags) do {						\
 	if ((gcret = v_key(sp, 0, &ev, ec_flags)) != GC_OK)		\
 		return (gcret);						\
 	if (ev.e_value == K_ESCAPE)					\
@@ -413,7 +413,7 @@ ret:		rval = 1;
 	if (F_ISSET(&ev.e_ch, CH_MAPPED))				\
 		*mappedp = 1;						\
 	key = ev.e_c;							\
-}
+} while (0)
 
 /*
  * The O_TILDEOP option makes the ~ command take a motion instead

--- a/vi/vs_line.c
+++ b/vi/vs_line.c
@@ -165,7 +165,7 @@ vs_line(SCR *sp, SMAP *smp, size_t *yp, size_t *xp)
 		 * Lots of special cases for empty lines, but they only apply
 		 * if we're displaying the first screen of the line.
 		 */
-		if (skip_cols == 0)
+		if (skip_cols == 0) {
 			if (dne) {
 				if (smp->lno == 1) {
 					if (list_dollar) {
@@ -176,12 +176,14 @@ vs_line(SCR *sp, SMAP *smp, size_t *yp, size_t *xp)
 					ch = '~';
 					goto empty;
 				}
-			} else
+			} else {
 				if (list_dollar) {
 					ch = '$';
 empty:					(void)gp->scr_addstr(sp,
 					    KEY_NAME(sp, ch), KEY_LEN(sp, ch));
 				}
+			}
+		}
 
 		(void)gp->scr_clrtoeol(sp);
 		(void)gp->scr_move(sp, oldy, oldx);
@@ -402,11 +404,11 @@ display:
 		if (is_cached || no_draw)
 			continue;
 
-#define	FLUSH {								\
+#define	FLUSH do {							\
 	*cbp = '\0';							\
 	(void)gp->scr_waddstr(sp, cbuf, cbp - cbuf);			\
 	cbp = cbuf;							\
-}
+} while (0)
 		/*
 		 * Display the character.  We do tab expansion here because
 		 * the screen interface doesn't have any way to set the tab

--- a/vi/vs_msg.c
+++ b/vi/vs_msg.c
@@ -240,12 +240,13 @@ vs_msg(SCR *sp, mtype_t mtype, char *line, size_t len)
 	 * XXX
 	 * Shouldn't we save this, too?
 	 */
-	if (F_ISSET(sp, SC_TINPUT_INFO) || F_ISSET(gp, G_BELLSCHED))
+	if (F_ISSET(sp, SC_TINPUT_INFO) || F_ISSET(gp, G_BELLSCHED)) {
 		if (F_ISSET(sp, SC_SCR_VI)) {
 			F_CLR(gp, G_BELLSCHED);
 			(void)gp->scr_bell(sp);
 		} else
 			F_SET(gp, G_BELLSCHED);
+	}
 
 	/*
 	 * If vi is using the error line for text input, there's no screen
@@ -271,13 +272,14 @@ vs_msg(SCR *sp, mtype_t mtype, char *line, size_t len)
 	 * the screen, so previous opinions are ignored.
 	 */
 	if (F_ISSET(sp, SC_EX | SC_SCR_EXWROTE)) {
-		if (!F_ISSET(sp, SC_SCR_EX))
+		if (!F_ISSET(sp, SC_SCR_EX)) {
 			if (F_ISSET(sp, SC_SCR_EXWROTE)) {
 				if (sp->gp->scr_screen(sp, SC_EX))
 					return;
 			} else
 				if (ex_init(sp))
 					return;
+		}
 
 		if (mtype == M_ERR)
 			(void)gp->scr_attr(sp, SA_INVERSE, 1);
@@ -339,13 +341,14 @@ vs_msg(SCR *sp, mtype_t mtype, char *line, size_t len)
 	padding += 2;
 
 	maxcols = sp->cols - 1;
-	if (vip->lcontinue != 0)
+	if (vip->lcontinue != 0) {
 		if (len + vip->lcontinue + padding > maxcols)
 			vs_output(sp, vip->mtype, ".\n", 2);
 		else  {
 			vs_output(sp, vip->mtype, ";", 1);
 			vs_output(sp, M_NONE, " ", 1);
 		}
+	}
 	vip->mtype = mtype;
 	for (s = line;; s = t) {
 		for (; len > 0 && isblank((u_char)*s); --len, ++s);
@@ -452,11 +455,11 @@ vs_output(SCR *sp, mtype_t mtype, const char *line, int llen)
 			(void)gp->scr_attr(sp, SA_INVERSE, 1);
 
 		/* Display the line, doing character translation. */
-#define	FLUSH {								\
+#define	FLUSH do {							\
 	*cbp = '\0';							\
 	(void)gp->scr_addstr(sp, cbuf, cbp - cbuf);			\
 	cbp = cbuf;							\
-}
+} while (0)
 		ecbp = (cbp = cbuf) + sizeof(cbuf) - 1;
 		for (t = line, tlen = len; tlen--; ++t) {
 			/*

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -241,7 +241,7 @@ vs_paint(
 	 * screen but the column offset is not, we'll end up in the adjust
 	 * code, when we should probably have compressed the screen.
 	 */
-	if (IS_SMALL(sp))
+	if (IS_SMALL(sp)) {
 		if (LNO < HMAP->lno) {
 			lcnt = vs_sm_nlines(sp, HMAP, LNO, sp->t_maxrows);
 			if (lcnt <= HALFSCREEN(sp))
@@ -278,6 +278,7 @@ small_fill:			(void)gp->scr_move(sp, LASTLINE(sp), 0);
 				goto adjust;
 			}
 		}
+	}
 
 	/*
 	 * 6b: Line down, or current screen.
@@ -390,7 +391,7 @@ top:		if (vs_sm_fill(sp, LNO, P_TOP))
 adjust:	if (!O_ISSET(sp, O_LEFTRIGHT) &&
 	    (LNO == HMAP->lno || LNO == TMAP->lno)) {
 		cnt = vs_screens(sp, LNO, &CNO);
-		if (LNO == HMAP->lno && cnt < HMAP->soff)
+		if (LNO == HMAP->lno && cnt < HMAP->soff) {
 			if ((HMAP->soff - cnt) > HALFTEXT(sp)) {
 				HMAP->soff = cnt;
 				vs_sm_fill(sp, OOBLNO, P_TOP);
@@ -399,7 +400,8 @@ adjust:	if (!O_ISSET(sp, O_LEFTRIGHT) &&
 				while (cnt < HMAP->soff)
 					if (vs_sm_1down(sp))
 						return (1);
-		if (LNO == TMAP->lno && cnt > TMAP->soff)
+		}
+		if (LNO == TMAP->lno && cnt > TMAP->soff) {
 			if ((cnt - TMAP->soff) > HALFTEXT(sp)) {
 				TMAP->soff = cnt;
 				vs_sm_fill(sp, OOBLNO, P_BOTTOM);
@@ -408,6 +410,7 @@ adjust:	if (!O_ISSET(sp, O_LEFTRIGHT) &&
 				while (cnt > TMAP->soff)
 					if (vs_sm_1up(sp))
 						return (1);
+		}
 	}
 
 	/*

--- a/vi/vs_relative.c
+++ b/vi/vs_relative.c
@@ -142,15 +142,16 @@ done:		if (diffp != NULL)		/* XXX */
 	 * last column of the screen.  Otherwise, display the rest of the
 	 * character in the next screen.
 	 */
-#define	TAB_RESET {							\
+#define	TAB_RESET do {							\
 	curoff += chlen;						\
-	if (!leftright && curoff >= sp->cols)				\
+	if (!leftright && curoff >= sp->cols) {				\
 		if (ch == '\t') {					\
 			curoff = 0;					\
 			scno -= scno % sp->cols;			\
 		} else							\
 			curoff -= sp->cols;				\
-}
+	}								\
+} while (0)
 	if (cnop == NULL)
 		while (len--) {
 			chlen = CHLEN(curoff);

--- a/vi/vs_smap.c
+++ b/vi/vs_smap.c
@@ -292,12 +292,12 @@ err:	HMAP->lno = 1;
  * so the screen map is refilled and the screen redrawn, and return.  This
  * is amazingly slow, but it's not clear that anyone will care.
  */
-#define	HANDLE_WEIRDNESS(cnt) {						\
+#define	HANDLE_WEIRDNESS(cnt) do {					\
 	if (cnt >= sp->t_rows) {					\
 		F_SET(sp, SC_SCR_REFORMAT);				\
 		return (0);						\
 	}								\
-}
+} while (0)
 
 /*
  * vs_sm_delete --


### PR DESCRIPTION
While building 04c163d under FreeBSD 12.1, clang 8.0.1 produces a lot of warnings, e.g:
```
CMake Warning at CMakeLists.txt:9 (message):
../common/mark.c:223:7: warning: add explicit braces to avoid dangling else [-Wdangling-else]
1 warning generated.
```
One cause are multi-statement macros wrapped with just braces. The usual way is to wrap multi-statements with `do {} while (0)` as described here: [Swallowing the Semicolon](https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html)

The other cause are nested if statements, e.g:
```
        if (lmp->lno >= lno)
                if (lmp->lno == lno) {
                        F_SET(lmp, MARK_DELETED);
                        (void)log_mark(sp, lmp);
                } else
                        --lmp->lno;
```
Add do {} while (0) and explicit braces where needed.