### PR TITLE
Undo `do {} while (0)` changes

### DIFF
--- a/catalog/dump.c
+++ b/catalog/dump.c
@@ -35,24 +35,24 @@ parse(FILE *fp)
 {
 	int ch, s1, s2, s3;
 
-#define	TESTD(s) do {							\
+#define	TESTD(s) {							\
 	if ((s = getc(fp)) == EOF)					\
 		return;							\
 	if (!isdigit(s))						\
 		continue;						\
-} while (0)
-#define	TESTP do {							\
+}
+#define	TESTP {								\
 	if ((ch = getc(fp)) == EOF)					\
 		return;							\
 	if (ch != '|')							\
 		continue;						\
-} while (0)
-#define	MOVEC(t) do {							\
+}
+#define	MOVEC(t) {							\
 	do {								\
 		if ((ch = getc(fp)) == EOF)				\
 			return;						\
 	} while (ch != (t));						\
-} while (0)
+}
 	for (;;) {
 		MOVEC('"');
 		TESTD(s1);


### PR DESCRIPTION
In this file, the macros include loop control statements `continue`.
Adding `do {} while (0)` to these macros breaks the main for loop of the
function. Remove them.

This partially reverts commit 05ed8b9b4016928e161d3d889bc1c443ce1d72dd.