### PR TITLE
Fix segmentation fault when window size changes

### DIFF
--- a/cl/cl_read.c
+++ b/cl/cl_read.c
@@ -317,10 +317,10 @@ cl_resize(SCR *sp, size_t lines, size_t columns)
 	argv[0] = &a;
 	argv[1] = &b;
 
-	a.len = SPRINTF(b1, sizeof(b1), L("lines=%lu"), (u_long)lines);
+	a.len = SPRINTF(b1, sizeof(b1) / sizeof(CHAR_T), L("lines=%lu"), (u_long)lines);
 	if (opts_set(sp, argv, NULL))
 		return (1);
-	a.len = SPRINTF(b1, sizeof(b1), L("columns=%lu"), (u_long)columns);
+	a.len = SPRINTF(b1, sizeof(b1) / sizeof(CHAR_T), L("columns=%lu"), (u_long)columns);
 	if (opts_set(sp, argv, NULL))
 		return (1);
 	return (0);


### PR DESCRIPTION
Platform: NixOS 20.09
Kernel: Linux 5.4.108 (`x86_64-linux`, glibc 2.31)

When widechar support is enabled, resizing the window causes a segmentation fault. This is caused by [cl/cl_read.c:320](https://github.com/lichray/nvi2/blob/master/cl/cl_read.c#L320) and [cl/cl_read.c:323](https://github.com/lichray/nvi2/blob/master/cl/cl_read.c#L323); with widechar support enabled, `sizeof(b1)` evaluates to `4096`, while `swprintf` expects the destination buffer length to be in terms of widechar count.

I did not get the chance to test this on any machines other than my own. I am happy to provide additional details if needed.