### PR TITLE
Fix buffer overflow in `ex_comm_search`

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -253,7 +253,7 @@ v_wstrdup(SCR *sp, const CHAR_T *str, size_t len)
 	if (copy == NULL)
 		return (NULL);
 	MEMCPY(copy, str, len);
-	copy[len] = '\0';
+	copy[len] = L('\0');
 	return (copy);
 }
 

--- a/ex/ex.c
+++ b/ex/ex.c
@@ -2266,7 +2266,8 @@ ex_comm_search(CHAR_T *name, size_t len)
 			return (NULL);
 		if (cp->name[0] != name[0])
 			continue;
-		if (!MEMCMP(name, cp->name, len))
+		if (STRLEN(cp->name) >= len &&
+			!MEMCMP(name, cp->name, len))
 			return (cp);
 	}
 	return (NULL);


### PR DESCRIPTION
Platform: NixOS 20.09
Kernel: Linux 5.4.109 (`x86_64-linux`, glibc 2.31)

This PR fixes a buffer overflow in [`ex_comm_search`](https://github.com/lichray/nvi2/blob/master/ex/ex.c#L2269). The overflow was found using AddressSanitizer, for which a build flag was added in `CMakeLists.txt`. I did not run into the linker error described by #92 both with and without widechar support, but this may be due to a difference in systems.