### PR TITLE
Fix segmentation fault in number increment

### DIFF
--- a/cl/cl_read.c
+++ b/cl/cl_read.c
@@ -317,10 +317,10 @@ cl_resize(SCR *sp, size_t lines, size_t columns)
 	argv[0] = &a;
 	argv[1] = &b;
 
-	a.len = SPRINTF(b1, sizeof(b1) / sizeof(CHAR_T), L("lines=%lu"), (u_long)lines);
+	a.len = SPRINTF(b1, SIZE(b1), L("lines=%lu"), (u_long)lines);
 	if (opts_set(sp, argv, NULL))
 		return (1);
-	a.len = SPRINTF(b1, sizeof(b1) / sizeof(CHAR_T), L("columns=%lu"), (u_long)columns);
+	a.len = SPRINTF(b1, SIZE(b1), L("columns=%lu"), (u_long)columns);
 	if (opts_set(sp, argv, NULL))
 		return (1);
 	return (0);

--- a/common/util.c
+++ b/common/util.c
@@ -253,7 +253,7 @@ v_wstrdup(SCR *sp, const CHAR_T *str, size_t len)
 	if (copy == NULL)
 		return (NULL);
 	MEMCPY(copy, str, len);
-	copy[len] = L('\0');
+	copy[len] = '\0';
 	return (copy);
 }
 

--- a/vi/v_increment.c
+++ b/vi/v_increment.c
@@ -198,7 +198,7 @@ nonum:			msgq(sp, M_ERR, "181|Cursor not in a number");
 		/* If we cross 0, signed numbers lose their sign. */
 		if (lval == 0 && ntype == fmt[SDEC])
 			ntype = fmt[DEC];
-		nlen = SPRINTF(nbuf, sizeof(nbuf), ntype, lval);
+		nlen = SPRINTF(nbuf, SIZE(nbuf), ntype, lval);
 	} else {
 		if ((nret = nget_uslong(&ulval, t, NULL, base)) != NUM_OK)
 			goto err;
@@ -220,7 +220,7 @@ nonum:			msgq(sp, M_ERR, "181|Cursor not in a number");
 		if (base == 16)
 			wlen -= 2;
 
-		nlen = SPRINTF(nbuf, sizeof(nbuf), ntype, wlen, ulval);
+		nlen = SPRINTF(nbuf, SIZE(nbuf), ntype, wlen, ulval);
 	}
 
 	/* Build the new line. */


### PR DESCRIPTION
Platform: NixOS 20.09
Kernel: Linux 5.4.111 (`x86_64-linux`, glibc 2.31)

This bug is identical in nature to #96---unscaled `sprintf` with wide characters. The commit also retroactively changes the fix in #96 to use the `SIZE` macro from `common/multibyte.h`.

My apologies about the piecemeal change requests. I am discovering these issues as I use the program. For completeness' sake, I checked the other instances of `SPRINTF` for the same bug, and it looks like the one fixed by this PR was the last remaining unscaled one.