### PR TITLE
Fix for terminal state corruption on `q` from `ex`-mode; fixes #105

### DIFF
--- a/ex/ex.c
+++ b/ex/ex.c
@@ -154,6 +154,10 @@ ex(SCR **spp)
 			if (file_end(sp, NULL, F_ISSET(sp, SC_EXIT_FORCE)))
 				return (1);
 			*spp = screen_next(sp);
+			if (*spp) {
+				F_CLR(*spp, SC_SCR_VI);
+				F_SET(*spp, SC_SCR_EX);
+			}
 			return (screen_end(sp));
 		}
 	}


### PR DESCRIPTION
Fixes #105.

Patched as per https://repo.or.cz/nvi.git/commit/72c797015c3a470a59106cd86bc18e63a7b2fd4e or https://github.com/johnsonjh/OpenVi/commit/cfa00dfb66d132d3cc4d4202c0bfc4ca817c5a03