### PR TITLE
Do a full reformat when `^L`/`^R` redrawing.

### DIFF
--- a/vi/v_redraw.c
+++ b/vi/v_redraw.c
@@ -29,5 +29,6 @@
 int
 v_redraw(SCR *sp, VICMD *vp)
 {
+	F_SET(sp, SC_SCR_REFORMAT);
 	return (sp->gp->scr_refresh(sp, 1));
 }


### PR DESCRIPTION
See issue #104 - adding a new step of "inputting four or five backspaces" to exit the command input leaves the screen in a state where `^L` or `^R` will not correct corruption until a reformat (`:set nonum|set num`, etc).

This is possible in other situations as well.

This ensures the screen is always reformatted and redrawn on `^L` or `^R`.