### PR TITLE
Fix core dump when tags file pattern has a trailing '\'

### DIFF
--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -1151,7 +1151,7 @@ re_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
 static int
 re_tag_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
 {
-	int blen, len;
+	size_t blen, len;
 	int lastdollar;
 	CHAR_T *bp, *p, *t;
 
@@ -1195,7 +1195,8 @@ re_tag_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
 	for (; len > 0; --len) {
 		if (p[0] == '\\' && (p[1] == '/' || p[1] == '?')) {
 			++p;
-			--len;
+			if (len > 1)
+				--len;
 		} else if (STRCHR(L("^.[]$*"), p[0]))
 			*t++ = '\\';
 		*t++ = *p++;

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -1151,7 +1151,7 @@ re_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
 static int
 re_tag_conv(SCR *sp, CHAR_T **ptrnp, size_t *plenp, int *replacedp)
 {
-	size_t blen, len;
+	int blen, len;
 	int lastdollar;
 	CHAR_T *bp, *p, *t;
 


### PR DESCRIPTION
... due to `size_t` being unsigned and a loop that checks for > 0 which is always true (even when the loop variable is decremented twice).

I found that I could crash nvi (both the @lichray fork and the version that comes with the base 13.1-RELEASE system) with a tags file for this macro:
 ```
#define LATIN2PLAIN(ch) (((u_char)ch) >= 0x80 ? \
    pgm_read_byte_far(pgm_get_far_address(latin2plain) + \
    (((u_char)ch) - 0x80)) : (isprint(ch) ? (ch) : '_'))
```
 I believe the trigger is the trailing '\\'. The crash happens in a loop in re_tag_conv():
```
/*
 * Escape every other magic character we can find, meanwhile stripping
 * the backslashes ctags inserts when escaping the search delimiter
 * characters.
 */
for (; len > 0; --len) {
        if (p[0] == '\\' && (p[1] == '/' || p[1] == '?')) {
                ++p;
                --len;
        } else if (STRCHR(L("^.[]$*"), p[0]))
                *t++ = '\\';
        *t++ = *p++;
}
```
The extra `--len` when len is already zero is the problem.

It's possible `size_t` was signed on the system nvi was developed. But at least [one source claims `size_t` is "always unsigned"](https://stackoverflow.com/a/1089181/2994620).

This PR only addresses the crash I could reproduce by making len an `int` (large enough for lines in a tags file). But there are more than 100 places where len is declared a `size_t` and many/most of them have loops with len > 0 as the condition. The simple fix for the rest of these would be to change `size_t` to `int`.

Another way to address this would be to look for places where the loop variable is a `size_t` and the loop variable is decremented inside the loop. But that seems fragile.



 
    
