### PR TITLE
Created INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,28 @@
+Installing from source
+======================
+
+If you are not familiar with "cmake" these instructions may be helpful when compiling from source and installing. 
+These instructions assume you have `cmake`, `git`, `make` and your C toolchain installed.
+
+1. Clone this repository and change into the source directory
+2. Use cmake to generate your "Unix Makefiles"
+3. Use make to build the nvi binary
+4. Copy/Move[^1] the nvi binary to your desired install location (e.g. `$HOME/bin`)
+5. Copy the manual page to your man path (e.g. `$HOME/man/man1`)
+6. Finally you can symlink nvi as nex to get the "ex" cli
+
+Here's the steps I took in my shell
+
+```
+git clone git@github.com:lichray/nvi2
+cd nvi2
+cmake --fresh -G "Unix Makefiles" .
+make
+mv nvi $HOME/bin/
+cp man/vi.1 $HOME/man/man1/
+cd $HOME/bin
+ln nvi nex
+cd
+```
+
+[^1]: On macOS you may need to use move (i.e. `mv`) instead of copy (i.e. `cp`)


### PR DESCRIPTION
fix: Add missing install document

Just added a quick install document so people who aren't familiar with cmake could build nvi2.