### PR TITLE
Fix handling escaped delimiter for ex_range function

### DIFF
--- a/common/search.c
+++ b/common/search.c
@@ -103,9 +103,14 @@ prev:			if (sp->re == NULL) {
 					++p;
 				break;
 			}
-			if (plen > 1 && p[0] == '\\' && p[1] == delim) {
-				++p;
-				--plen;
+			if (plen > 1 && p[0] == '\\') {
+				if (p[1] == delim) {
+					++p;
+					--plen;
+				} else if ( p[1] == '\\') {
+					*t++ = *p++;
+					--plen;
+				}
 			}
 		}
 		if (epp != NULL)


### PR DESCRIPTION
Function search_init removes escape character if it escapes a delimiter, but it should consider when an backslash character is not an escape character (this occurs when two backslash). In latter case the escape character should be included in re string.

This patch can be tested with the following commands.
$ printf '%s\n' '\\' > test.txt
$ printf '%s\n' '/\\\\/' 'q' | ex test.txt

Before this patch the previous command gives 'Pattern not found', because the last two caracters of the command becomes the single delimiter in the regular expression, i.e. it didn't recognize the delimiter.