### PR TITLE
ex: fix printing of line number when the 's' command is used with the 'c' flag and the number option is set.

### DIFF
--- a/ex/ex.c
+++ b/ex/ex.c
@@ -1467,8 +1467,14 @@ addr_verify:
 		LF_INIT(FL_ISSET(ecp->iflags, E_C_HASH | E_C_LIST | E_C_PRINT));
 		if (!LF_ISSET(E_C_HASH | E_C_LIST | E_C_PRINT | E_NOAUTO) &&
 		    !F_ISSET(sp, SC_EX_GLOBAL) &&
-		    O_ISSET(sp, O_AUTOPRINT) && F_ISSET(ecp, E_AUTOPRINT))
-			LF_INIT(E_C_PRINT);
+		    O_ISSET(sp, O_AUTOPRINT) && F_ISSET(ecp, E_AUTOPRINT)) {
+
+			/* Honor the number option if autoprint is set. */
+			if (F_ISSET(ecp, E_OPTNUM))
+				LF_INIT(E_C_HASH);
+			else
+				LF_INIT(E_C_PRINT);
+		}
 
 		if (LF_ISSET(E_C_HASH | E_C_LIST | E_C_PRINT)) {
 			cur.lno = sp->lno;

--- a/ex/ex_subst.c
+++ b/ex/ex_subst.c
@@ -643,7 +643,9 @@ nextmatch:	match[0].rm_so = 0;
 					goto lquit;
 				}
 			} else {
-				if (ex_print(sp, cmdp, &from, &to, 0) ||
+				const int flags =
+				    O_ISSET(sp, O_NUMBER) ? E_C_HASH : 0;
+				if (ex_print(sp, cmdp, &from, &to, flags) ||
 				    ex_scprint(sp, &from, &to))
 					goto lquit;
 				if (ex_txt(sp, tiq, 0, TXT_CR))


### PR DESCRIPTION
Currently, given the line:
```
Five women came to the party.
```
issuing the command in ex when the number option is enabled (the output is fine if number is not enabled):
```
:s/men/MEN/c
```
will display:
```
Five women came to the party.
               ^^^[ynq]
```
The confirmation line is indented properly for output when the number option is enabled, but the line above it lacks the expected line number.  The output should be, e.g.:
```
     1  Five women came to the party.
               ^^^[ynq]
```

The line number is also missing when the line is reprinted after the confirmation prompt.  With the changes in this PR, the output becomes:
```
:set number
:s/men/MEN/c
     1  Five women came to the party.
               ^^^[ynq]n
     1  Five women came to the party.
```

This matches historic ex behavior and appears to match POSIX, though it is not 100% clear on this specific issue.