### PR TITLE
Treat consecutive paragraph indicators as different paragraphs

### DIFF
--- a/vi/v_paragraph.c
+++ b/vi/v_paragraph.c
@@ -39,15 +39,20 @@
 	if (p[0] == '\014') {						\
 		if (!--cnt)						\
 			goto found;					\
+		if (pstate == P_INTEXT && !--cnt)			\
+			goto found;					\
 		continue;						\
 	}								\
 	if (p[0] != '.' || len < 2)					\
 		continue;						\
 	for (lp = VIP(sp)->ps; *lp != '\0'; lp += 2)			\
 		if (lp[0] == p[1] &&					\
-		    (lp[1] == ' ' && len == 2 || lp[1] == p[2]) &&	\
-		    !--cnt)						\
-			goto found;					\
+		    (lp[1] == ' ' && len == 2 || lp[1] == p[2])) {	\
+			if (!--cnt)					\
+				goto found;				\
+			if (pstate == P_INTEXT && !--cnt)		\
+				goto found;				\
+		}							\
 } while (0)
 
 /*


### PR DESCRIPTION
Consecutive empty lines count toward the same state, so there're 2x states (to get in and out). ^L and .PP are counted as text, hitting those in the text should be treated as getting out of a paragraph and then getting in.

Closes: #118
See also: https://marc.info/?l=openbsd-bugs&m=169100763926909&w=2