### PR TITLE
fix last left-over K&R function declaration

### DIFF
--- a/common/main.c
+++ b/common/main.c
@@ -419,8 +419,7 @@ err:		rval = 1;
  * PUBLIC: void v_end(GS *);
  */
 void
-v_end(gp)
-	GS *gp;
+v_end(GS *gp)
 {
 	MSGS *mp;
 	SCR *sp;


### PR DESCRIPTION
> a function definition without a prototype is deprecated in all
> versions of C and is not supported in C2x

Fix the last straggler.