### PR TITLE
Replace Clang-only __builtin_is_aligned with C code

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -709,7 +709,7 @@ apply_with(int (*db_func)(SCR *, recno_t, CHAR_T *, size_t), SCR *sp,
 	static size_t blen;
 	static u_char *bp;
 
-	if (!__builtin_is_aligned(p, sizeof(unsigned long))) {
+	if (!is_aligned(p, sizeof(unsigned long))) {
 		if (len > blen) {
 			blen = p2roundup(MAX(len, 512));
 			REALLOC(sp, bp, u_char *, blen);

--- a/common/mem.h
+++ b/common/mem.h
@@ -212,6 +212,18 @@ p2roundup(size_t n)
 	return (n);
 }
 
+/*
+ * is_aligned --
+ *      Determine whether the program can safely read an object with an
+ *      alignment requirement from ptr.
+ *
+ * See also: https://clang.llvm.org/docs/LanguageExtensions.html#alignment-builtins
+ */
+static __inline int
+is_aligned(void *ptr, size_t alignment) {
+	return ((uintptr_t)ptr % alignment) == 0;
+}
+
 /* Additional TAILQ helper. */
 #define TAILQ_ENTRY_ISVALID(elm, field)					\
 	((elm)->field.tqe_prev != NULL)


### PR DESCRIPTION
We should use alignof in the future.

Closes: #123