### PR TITLE
Add missing stdint.h header for uintptr_t

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -17,6 +17,7 @@
 #include <db.h>
 #endif
 #include <regex.h>		/* May refer to the bundled regex. */
+#include <stdint.h>
 
 /*
  * Forward structure declarations.  Not pretty, but the include files

--- a/common/log.c
+++ b/common/log.c
@@ -18,7 +18,6 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Hello. After the [last commit](https://github.com/lichray/nvi2/commit/25c4d7db4ea638a31ac458b733a3b67b0a0ff634) I can't anymore build nvi2 on OpenBSD, because I meet the error:
`error: use of undeclared identifier 'uintptr_t'`.

In this PR, I added a header with declaration for uintptr_t.