### PR TITLE
Fix undefined string comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ if (NOT APPLE)
 endif()
 add_compile_options($<$<CONFIG:Release>:-Wuninitialized>)
 add_compile_options($<$<CONFIG:Release>:-Wno-dangling-else>)
-add_compile_options(-Wno-string-compare)
 add_compile_options(-Wstack-protector -fstack-protector)
 add_compile_options(-Wstrict-aliasing -fstrict-aliasing)
 

--- a/common/options.c
+++ b/common/options.c
@@ -317,7 +317,7 @@ opts_init(SCR *sp, int *oargs)
 	/* Set numeric and string default values. */
 #define	OI(indx, str) do {						\
 	a.len = STRLEN(str);						\
-	if (STRCMP((CHAR_T*)str, b2))					\
+	if (STRCMP((CHAR_T*)str, b2) != 0)					\
 		(void)MEMCPY(b2, str, a.len+1);				\
 	if (opts_set(sp, argv, NULL)) {					\
 		 optindx = indx;					\

--- a/common/options.c
+++ b/common/options.c
@@ -317,7 +317,7 @@ opts_init(SCR *sp, int *oargs)
 	/* Set numeric and string default values. */
 #define	OI(indx, str) do {						\
 	a.len = STRLEN(str);						\
-	if ((CHAR_T*)str != b2)	  /* GCC puts strings in text-space. */	\
+	if (STRCMP((CHAR_T*)str, b2))					\
 		(void)MEMCPY(b2, str, a.len+1);				\
 	if (opts_set(sp, argv, NULL)) {					\
 		 optindx = indx;					\


### PR DESCRIPTION
Minor fix.

I changed a string comparison that used `!=` instead of `STRCMP`, the macro for `wcscmp`.
I removed the `no-string-compare` option in `CMakeLists.txt` as it doesn't seen needed any more.