### PR TITLE
Add showfilename configuration option

### DIFF
--- a/common/options.c
+++ b/common/options.c
@@ -181,6 +181,8 @@ OPTLIST const optlist[] = {
 	{L("shellmeta"),	NULL,		OPT_STR,	0},
 /* O_SHIFTWIDTH	    4BSD */
 	{L("shiftwidth"),	NULL,		OPT_NUM,	OPT_NOZERO},
+/* O_SHOWFILENAME */
+	{L("showfilename"),	NULL,		OPT_0BOOL,	0},
 /* O_SHOWMATCH	    4BSD */
 	{L("showmatch"),	NULL,		OPT_0BOOL,	0},
 /* O_SHOWMODE	  4.4BSD */

--- a/man/vi.1
+++ b/man/vi.1
@@ -2505,6 +2505,10 @@ Set the meta characters checked to determine if file name expansion
 is necessary.
 .It Cm shiftwidth , sw Bq 8
 Set the autoindent and shift command indentation width.
+.It Cm showfilename Bq off
+.Nm vi
+only.
+Display the file name on the colon command line.
 .It Cm showmatch , sm Bq off
 .Nm vi
 only.

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -795,7 +795,7 @@ vs_modeline(SCR *sp)
 
 	/* If more than one screen in the display, show the file name. */
 	curlen = 0;
-	if (IS_SPLIT(sp)) {
+	if (IS_SPLIT(sp) || O_ISSET(sp, O_SHOWFILENAME)) {
 		CHAR_T *wp, *p;
 		size_t l;
 


### PR DESCRIPTION
When having a few instances of vi open next to each other (using a window manager), pressing control-G all the time to understand 'what file is in what window' is tedious. Instead, offer a configurable option (default off) to display the file name in the lower left corner.