### PR TITLE
In ruler show the current line number as a percentage of the total lines

### DIFF
--- a/man/vi.1
+++ b/man/vi.1
@@ -2482,7 +2482,7 @@ Set the number of lines about which the editor reports changes or yanks.
 .It Cm ruler Bq off
 .Nm vi
 only.
-Display a row/column ruler on the colon command line.
+Display a row/column/percentage ruler on the colon command line.
 .It Cm scroll , scr Bq "window size / 2"
 Set the number of lines scrolled.
 .It Cm searchincr Bq off

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -774,7 +774,8 @@ vs_modeline(SCR *sp)
 	size_t cols, curcol, curlen, endpoint, len, midpoint;
 	const char *t = NULL;
 	int ellipsis;
-	char buf[20];
+	char buf[30];
+	recno_t last;
 
 	gp = sp->gp;
 
@@ -846,8 +847,14 @@ vs_modeline(SCR *sp)
 	cols = sp->cols - 1;
 	if (O_ISSET(sp, O_RULER)) {
 		vs_column(sp, &curcol);
-		len = snprintf(buf, sizeof(buf), "%lu,%lu",
-		    (u_long)sp->lno, (u_long)(curcol + 1));
+
+		if (db_last(sp, &last) || last == 0)
+			len = snprintf(buf, sizeof(buf), "%lu,%zu",
+			    (u_long)sp->lno, curcol + 1);
+		else
+			len = snprintf(buf, sizeof(buf), "%lu,%zu %lu%%",
+			    (u_long)sp->lno, curcol + 1,
+			    (u_long)(sp->lno * 100) / last);
 
 		midpoint = (cols - ((len + 1) / 2)) / 2;
 		if (curlen < midpoint) {


### PR DESCRIPTION
Modeled after control-G, will only show the percentage if the last line can be determined.

From OpenBSD https://github.com/openbsd/src/commit/b254483d64afb832597affd199aa63d6d99b70a3