### PR TITLE
Rename "extern.h" headers and improve header generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 *~
 *.orig
 *.core
-*_def.h
-version.h
 tags
 build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *~
 *.orig
 *.core
-extern.h
 *_def.h
 version.h
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,6 @@ add_compile_options(-Wstrict-aliasing -fstrict-aliasing)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-set(MAIN_PROTOS
-    common/options_def.h ex/ex_def.h ex/version.h)
-
 set(CL_SRCS
     cl/cl_funcs.c cl/cl_main.c cl/cl_read.c cl/cl_screen.c cl/cl_term.c)
 
@@ -80,11 +77,14 @@ set(VI_SRCS
 set(REGEX_SRCS
     regex/regcomp.c regex/regerror.c regex/regexec.c regex/regfree.c)
 
-set(EXTERN_HDRS
+set(GENERATED_HDRS
     ${CMAKE_CURRENT_BINARY_DIR}/cl_extern.h
     ${CMAKE_CURRENT_BINARY_DIR}/common_extern.h
     ${CMAKE_CURRENT_BINARY_DIR}/ex_extern.h
-    ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h)
+    ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h
+    ${CMAKE_CURRENT_BINARY_DIR}/options_def.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ex_def.h
+    ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
 # commands to generate the public headers
 set(extract_protos sed -n 's/^ \\* PUBLIC: \\\(.*\\\)/\\1/p')
@@ -111,24 +111,25 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h
                            ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ${VI_SRCS})
-
-add_custom_command(OUTPUT common/options_def.h
-                   COMMAND awk -f common/options.awk
-                           common/options.c > common/options_def.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/options_def.h
+                   COMMAND awk -f common/options.awk common/options.c >
+                           ${CMAKE_CURRENT_BINARY_DIR}/options_def.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS common/options.c)
-add_custom_command(OUTPUT ex/ex_def.h
-                   COMMAND awk -f ex/ex.awk ex/ex_cmd.c > ex/ex_def.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ex_def.h
+                   COMMAND awk -f ex/ex.awk ex/ex_cmd.c >
+                           ${CMAKE_CURRENT_BINARY_DIR}/ex_def.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ex/ex_cmd.c)
-add_custom_command(OUTPUT ex/version.h
-                   COMMAND ${extract_version} README > ex/version.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.h
+                   COMMAND ${extract_version} README >
+                           ${CMAKE_CURRENT_BINARY_DIR}/version.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS README)
 
 add_executable(nvi)
-target_sources(nvi PRIVATE ${MAIN_PROTOS} ${CL_SRCS} ${COMMON_SRCS}
-                           ${EX_SRCS} ${VI_SRCS} ${EXTERN_HDRS})
+target_sources(nvi PRIVATE ${CL_SRCS} ${COMMON_SRCS} ${EX_SRCS} ${VI_SRCS}
+                           ${GENERATED_HDRS})
 target_compile_definitions(nvi PRIVATE $<$<CONFIG:Debug>:DEBUG>
                                        $<$<CONFIG:Debug>:COMLOG>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ add_compile_options(-Wstrict-aliasing -fstrict-aliasing)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(MAIN_PROTOS
-    cl/extern.h common/extern.h ex/extern.h vi/extern.h
     common/options_def.h ex/ex_def.h ex/version.h)
 
 set(CL_SRCS
@@ -81,27 +80,38 @@ set(VI_SRCS
 set(REGEX_SRCS
     regex/regcomp.c regex/regerror.c regex/regexec.c regex/regfree.c)
 
+set(EXTERN_HDRS
+    ${CMAKE_CURRENT_BINARY_DIR}/cl_extern.h
+    ${CMAKE_CURRENT_BINARY_DIR}/common_extern.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ex_extern.h
+    ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h)
+
 # commands to generate the public headers
 set(extract_protos sed -n 's/^ \\* PUBLIC: \\\(.*\\\)/\\1/p')
 set(extract_version sed -n
     's/^.*version \\\([^\)]*\)\\\).*/\#define VI_VERSION \\\"\\1\\\"/p')
 
-add_custom_command(OUTPUT cl/extern.h
-                   COMMAND ${extract_protos} ${CL_SRCS} > cl/extern.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cl_extern.h
+                   COMMAND ${extract_protos} ${CL_SRCS} >
+                           ${CMAKE_CURRENT_BINARY_DIR}/cl_extern.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ${CL_SRCS})
-add_custom_command(OUTPUT common/extern.h
-                   COMMAND ${extract_protos} ${COMMON_SRCS} > common/extern.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/common_extern.h
+                   COMMAND ${extract_protos} ${COMMON_SRCS} >
+                           ${CMAKE_CURRENT_BINARY_DIR}/common_extern.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ${COMMON_SRCS})
-add_custom_command(OUTPUT ex/extern.h
-                   COMMAND ${extract_protos} ${EX_SRCS} > ex/extern.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ex_extern.h
+                   COMMAND ${extract_protos} ${EX_SRCS} >
+                           ${CMAKE_CURRENT_BINARY_DIR}/ex_extern.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ${EX_SRCS})
-add_custom_command(OUTPUT vi/extern.h
-                   COMMAND ${extract_protos} ${VI_SRCS} > vi/extern.h
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h
+                   COMMAND ${extract_protos} ${VI_SRCS} >
+                           ${CMAKE_CURRENT_BINARY_DIR}/vi_extern.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    DEPENDS ${VI_SRCS})
+
 add_custom_command(OUTPUT common/options_def.h
                    COMMAND awk -f common/options.awk
                            common/options.c > common/options_def.h
@@ -118,7 +128,7 @@ add_custom_command(OUTPUT ex/version.h
 
 add_executable(nvi)
 target_sources(nvi PRIVATE ${MAIN_PROTOS} ${CL_SRCS} ${COMMON_SRCS}
-                           ${EX_SRCS} ${VI_SRCS})
+                           ${EX_SRCS} ${VI_SRCS} ${EXTERN_HDRS})
 target_compile_definitions(nvi PRIVATE $<$<CONFIG:Debug>:DEBUG>
                                        $<$<CONFIG:Debug>:COMLOG>)
 

--- a/cl/cl.h
+++ b/cl/cl.h
@@ -77,4 +77,4 @@ typedef enum { INP_OK=0, INP_EOF, INP_ERR, INP_INTR, INP_TIMEOUT } input_t;
 #define	RCNO(sp, cno)	(cno)
 #define	RLNO(sp, lno)	(lno)
 
-#include "extern.h"
+#include "cl_extern.h"

--- a/common/common.h
+++ b/common/common.h
@@ -92,4 +92,4 @@ typedef enum { SEQ_ABBREV, SEQ_COMMAND, SEQ_INPUT } seq_t;
 #include "log.h"
 #include "mem.h"
 
-#include "extern.h"
+#include "common_extern.h"

--- a/common/recover.c
+++ b/common/recover.c
@@ -34,8 +34,8 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "../ex/version.h"
 #include "common.h"
+#include "version.h"
 #include "pathnames.h"
 
 /*

--- a/ex/ex.h
+++ b/ex/ex.h
@@ -228,4 +228,4 @@ typedef enum {
 } tagmsg_t;
 
 #include "ex_def.h"
-#include "extern.h"
+#include "ex_extern.h"

--- a/vi/vi.h
+++ b/vi/vi.h
@@ -381,4 +381,4 @@ typedef enum {
 	VIM_NOCOM, VIM_NOCOM_B, VIM_USAGE, VIM_WRESIZE
 } vim_t;
 
-#include "extern.h"
+#include "vi_extern.h"


### PR DESCRIPTION
* There were four `extern.h` files (i.e., `cl/extern.h`, `common/extern.h`,
  `ex/extern.h` and `vi/extern.h`).  Their same name was causing difficulties
  in importing nvi2 to other projects (e.g., FreeBSD and DragonFly BSD).

  For example, FreeBSD combined the four files but needed to manually add some
  ad-hoc `ifdef`'s; DragonFly BSD kept them separate but needed to slightly
  modify the source code (see also: https://github.com/DragonFlyBSD/DragonFlyBSD/commit/c5dc3490307750c42597d75ead72f8fc2eadcbfb).

  So rename them to be `cl_extern.h`, `common_extern.h`, `ex_extern.h` and
  `vi_extern.h`.

* The `extern.h` files and several other headers were generated directly in
  the source tree.  We should better avoid that because we're using
  out-of-source build.  Therefor, update to generate the headers in the build
  directory.

* Adjust the source code accordingly due to the header changes.