### PR TITLE
Handle out-of-band lines in expandtab

### DIFF
--- a/common/cut.c
+++ b/common/cut.c
@@ -68,6 +68,10 @@ cut(SCR *sp, CHAR_T *namep, MARK *fm, MARK *tm, int flags)
 	recno_t lno;
 	int append, copy_one, copy_def;
 
+	/* Check if the line numbers are out-of-band */
+	if (fm->lno == OOBLNO || tm->lno == OOBLNO)
+		return (1);
+
 	/*
 	 * If the user specified a buffer, put it there.  (This may require
 	 * a copy into the numeric buffers.  We do the copy so that we don't
@@ -175,6 +179,7 @@ cut_line_err:
 	text_lfree(cbp->textq);
 	cbp->len = 0;
 	cbp->flags = 0;
+	sp->gp->dcbp = NULL;
 	return (1);
 }
 

--- a/common/line.c
+++ b/common/line.c
@@ -51,7 +51,7 @@ db_eget(SCR *sp,
 	 * line in an empty file, find the last line of the file; db_last
 	 * fails loudly.
 	 */
-	if ((lno == 0 || lno == 1) && db_last(sp, &l1))
+	if ((lno == OOBLNO || lno == 1) && db_last(sp, &l1))
 		return (1);
 
 	/* If the file isn't empty, fail loudly. */
@@ -92,7 +92,7 @@ db_get(SCR *sp,
 	 * have to have an OOB condition for the look-aside into the input
 	 * buffer anyway.
 	 */
-	if (lno == 0)
+	if (lno == OOBLNO)
 		goto err1;
 
 	/* Check for no underlying file. */

--- a/ex/ex_bang.c
+++ b/ex/ex_bang.c
@@ -174,8 +174,8 @@ ex_bang(SCR *sp, EXCMD *cmdp)
 	if (!F_ISSET(sp, SC_VI) && !F_ISSET(sp, SC_EX_SILENT))
 		(void)ex_puts(sp, "!\n");
 
-	/* Apply expandtab to the new text */
-	if (O_ISSET(sp, O_EXPANDTAB))
+	/* If addresses were specified, apply expandtab to the new text */
+	if (cmdp->addrcnt != 0 && O_ISSET(sp, O_EXPANDTAB))
 		ex_retab(sp, cmdp);
 
 	/*

--- a/ex/ex_shift.c
+++ b/ex/ex_shift.c
@@ -79,8 +79,12 @@ shift(SCR *sp, EXCMD *cmdp, enum which rl)
 		return (0);
 	}
 
-	/* Copy the lines being shifted into the unnamed buffer. */
-	if (cut(sp, NULL, &cmdp->addr1, &cmdp->addr2, CUT_LINEMODE))
+	/*
+	 * When not doing re-expand tabs, copy the lines being shifted into
+	 * the unnamed buffer.
+	 */
+	if (rl != RETAB &&
+	    cut(sp, NULL, &cmdp->addr1, &cmdp->addr2, CUT_LINEMODE))
 		return (1);
 
 	/*


### PR DESCRIPTION
The procedure that causes the bug:
* open vi with set expandtab
* yy -> yank something
* :di b -> shows that the default buffer have the text copied
* :!ls >/dev/null run an external command without filtering lines, all commands are the same
* :di b -> already shows something strange, outputting: ********** default buffer (character mode) note that when the buffers are empty :di b shows: No cut buffers to display.
* p -> trying to paste segfault

A bug that does not segfault occurs also with the bang command, but when filtering lines:
* open vi with set expandtab
* yy -> yank something and then move to an other line
* :di b -> shows that the default buffer have the text copied
* :.!ls >/dev/null run an external command filtering any range of lines, both one address or two is the same, noticing the content of the line you are on
* :di b -> shows that the line(s) being put into the default buffer is(are) the line(s) that is(are) now under the cursor, not the original deleted ones

Running the bang without filtering files leaves the sp->gp->dcb_store as a dangling pointer.

Closes: #151