### PR TITLE
Insert empty line for trailing delimiter or newline

### DIFF
--- a/ex/ex.c
+++ b/ex/ex.c
@@ -773,6 +773,7 @@ skip_srch:	if (ecp->cmd == &cmds[C_VISUAL_EX] && F_ISSET(sp, SC_VI))
 	 * no longer useful.
 	 */
 	vi_address = ecp->clen != 0 && ecp->cp[0] != '\n';
+	ecp->trailing = 0;
 	for (p = ecp->cp; ecp->clen > 0; --ecp->clen, ++ecp->cp) {
 		ch = ecp->cp[0];
 		if (IS_ESCAPE(sp, ecp, ch) && ecp->clen > 1) {
@@ -788,6 +789,7 @@ skip_srch:	if (ecp->cmd == &cmds[C_VISUAL_EX] && F_ISSET(sp, SC_VI))
 				ch = tmp;
 			}
 		} else if (ch == '\n' || ch == '|') {
+			ecp->trailing = 1;
 			if (ch == '\n')
 				F_SET(ecp, E_NEWLINE);
 			--ecp->clen;

--- a/ex/ex.h
+++ b/ex/ex.h
@@ -99,7 +99,8 @@ struct _excmd {
 #define	AGV_GLOBAL	0x04		/* global command. */
 #define	AGV_V		0x08		/* v command. */
 #define	AGV_ALL		(AGV_AT | AGV_AT_NORANGE | AGV_GLOBAL | AGV_V)
-	u_int8_t  agv_flags;
+	u_int8_t  agv_flags : 4;
+	u_int8_t  trailing : 1;		/* Command had trailing | or \n. */
 
 	/* Clear the structure before each ex command. */
 #define	CLEAR_EX_CMD(cmdp) do {						\

--- a/ex/ex_append.c
+++ b/ex/ex_append.c
@@ -181,6 +181,9 @@ ex_aci(SCR *sp, EXCMD *cmdp, enum which cmd)
 		if (len != 0)
 			cmdp->save_cmd = t;
 		cmdp->save_cmdlen = len;
+	} else if (cmdp->trailing) {
+		if (db_append(sp, 1, lno++, NULL, 0))
+			return 1;
 	}
 
 	if (F_ISSET(sp, SC_EX_GLOBAL)) {


### PR DESCRIPTION
A trailing delimiter should cause an empty line to be inserted and this is also what the version of vi that comes with AIX and that identifies itself as "Version 3.10" does.

Keep track of the removal of a trailing delimiter or newline so that an empty line can be inserted when this removal results in an empty trailing text.

Closes: #135