### PR TITLE
Fix g command number of lines adjustment

### DIFF
--- a/ex/ex_global.c
+++ b/ex/ex_global.c
@@ -269,10 +269,10 @@ ex_g_insdel(SCR *sp, lnop_t op, recno_t lno)
 				continue;
 			
 			/*
-			 * If range greater than the line, decrement or
-			 * increment the range.
+			 * If range is greater than or equal to the line,
+			 * decrement or increment the range.
 			 */
-			if (rp->start > lno) {
+			if (rp->start >= lno) {
 				if (op == LINE_DELETE) {
 					--rp->start;
 					--rp->stop;


### PR DESCRIPTION
Without the change, g command adjusts lines only after processing the current line, causing a g command that requires inserting a line on every line processed to fail in the middle. To reproduce,

    :r !jot 7
    :g/^/t.

Closes: #164